### PR TITLE
Use the same version name in the compressed package as the build does

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,6 +18,9 @@ case "$(go env GOARCH)" in
 esac
 
 version=$(git describe --tags --always)
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+	version="$version-unsupported"
+fi
 
 AUTO_GOPATH=1 GOMAXPROCS=1 DOCKER_LDFLAGS="-s" ./hack/make.sh binary-balena
 


### PR DESCRIPTION
**- What I did**
Ported the git commit -> version logic from `hack/make.sh` to `build.sh`

**- How to verify it**
Run `build.sh` and checked the name of the final compressed file, in an unclean repo being `balena-SHA-unsupported-ARCH.tar.gz`, where `SHA-unsupported` is the same as output in the headers of the build process by `hack/make.sh`

**- Description for the changelog**
When building from an unclean git repo, `hack/make.sh` appends `-unsupported` to the version (commit) that is being built. Replicate that in the case of the compressed package output by `build.sh`, for consistency.

Signed-off-by: Gergely Imreh <imrehg@gmail.com>-

**- A picture of a cute animal (not mandatory but encouraged)**
![picture-owl-best-25-owls-ideas-on-pinterest-pics-of-owls-beautiful-owl-and-free](https://user-images.githubusercontent.com/38863/41124271-52cce292-6a99-11e8-94e1-a4ab8f7750f6.jpg)

