### PR TITLE
Added DOCKER_RAMDISK option back

### DIFF
--- a/libcontainerd/client_daemon.go
+++ b/libcontainerd/client_daemon.go
@@ -264,6 +264,7 @@ func (c *client) Start(ctx context.Context, id, checkpointDir string, withStdin 
 			info.Options = &runctypes.CreateOptions{
 				IoUid: uint32(uid),
 				IoGid: uint32(gid),
+				NoPivotRoot: os.Getenv("BALENA_ENGINE_RAMDISK") != "",
 			}
 			return nil
 		})


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/balena-os/balena-engine/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For general information on balenaEngine visit https://www.balenaengine.io

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
**- Why I did it**
I was using docker on my buildroot system. The system is using a initramfs, with the docker images stored on flash. When using docker I had to set the flag `DOCKER_RAMDISK=true` in my environment to disable the pivot root and be able to run docker images. 
I'm currently switching to Balena and found that this flag was removed. I was testing some things and found that the flag could be added back.
**- What I did**
Added back the flag in the `libcontainerd/client_daemon.go`. I also renamed it from `DOCKER_RAMDISK` to `BALENA_ENGINE_RAMDISK` to keep names consistent in the project.
**- How to verify**
Intall Balena in a buildroot system with a initramfs. When running an image it should fail.
Set the flag by`export BALENA_ENGINE_RAMDISK=true` or add to the service file `Environment="BALENA_ENGINE_RAMDISK=true"`
Restart the Balena service or daemon and run an image again.
**- Description for the changelog**
Added back the ramdisk flag to be able to run containers on a initramfs system.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->