### PR TITLE
Allow tagging of image deltas on creation

### DIFF
--- a/api/server/router/image/backend.go
+++ b/api/server/router/image/backend.go
@@ -25,7 +25,7 @@ type containerBackend interface {
 }
 
 type imageBackend interface {
-	DeltaCreate(deltaSrc, deltaDest string, outStream io.Writer) error
+	DeltaCreate(deltaSrc, deltaDest string, options types.ImageDeltaOptions, outStream io.Writer) error
 	ImageDelete(imageRef string, force, prune bool) ([]types.ImageDeleteResponseItem, error)
 	ImageHistory(imageName string) ([]*image.HistoryResponseItem, error)
 	Images(imageFilters filters.Args, all bool, withExtraAttrs bool) ([]*types.ImageSummary, error)

--- a/api/server/router/image/image_routes.go
+++ b/api/server/router/image/image_routes.go
@@ -170,12 +170,16 @@ func (d *imageRouter) postImagesDelta(ctx context.Context, w http.ResponseWriter
 	deltaSrc := r.Form.Get("src")
 	deltaDest := r.Form.Get("dest")
 
+	deltaOptions := types.ImageDeltaOptions{
+		Tag: r.Form.Get("t"),
+	}
+
 	output := ioutils.NewWriteFlusher(w)
 	defer output.Close()
 
 	w.Header().Set("Content-Type", "application/json")
 
-	if err := d.backend.DeltaCreate(deltaSrc, deltaDest, output); err != nil {
+	if err := d.backend.DeltaCreate(deltaSrc, deltaDest, deltaOptions, output); err != nil {
 		if !output.Flushed() {
 			return err
 		}

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -198,6 +198,11 @@ type ImageCreateOptions struct {
 	Platform     string // Platform is the target platform of the image if it needs to be pulled from the registry.
 }
 
+// ImageDeltaOptions holds information to create image deltas
+type ImageDeltaOptions struct {
+	Tag string
+}
+
 // ImageImportSource holds source information for ImageImport
 type ImageImportSource struct {
 	Source     io.Reader // Source is the data to send to the server to create this image from. You must set SourceName to "-" to leverage this.

--- a/client/image_delta.go
+++ b/client/image_delta.go
@@ -5,12 +5,17 @@ import (
 	"net/url"
 
 	"golang.org/x/net/context"
+
+	"github.com/docker/docker/api/types"
 )
 
 // ImageImport creates a new image based in the source options.
 // It returns the JSON content in the response body.
-func (cli *Client) ImageDelta(ctx context.Context, src, dest string) (io.ReadCloser, error) {
-	query := url.Values{}
+func (cli *Client) ImageDelta(ctx context.Context, src, dest string, options types.ImageDeltaOptions) (io.ReadCloser, error) {
+	query, err := cli.imageDeltaOptionsToQuery(options)
+	if err != nil {
+		return nil, err
+	}
 	query.Set("src", src)
 	query.Set("dest", dest)
 
@@ -19,4 +24,10 @@ func (cli *Client) ImageDelta(ctx context.Context, src, dest string) (io.ReadClo
 		return nil, err
 	}
 	return resp.body, nil
+}
+
+func (cli *Client) imageDeltaOptionsToQuery(options types.ImageDeltaOptions) (url.Values, error) {
+	query := url.Values{}
+	query.Set("t", options.Tag)
+	return query, nil
 }

--- a/client/interface.go
+++ b/client/interface.go
@@ -84,7 +84,7 @@ type ImageAPIClient interface {
 	ImageBuild(ctx context.Context, context io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
 	BuildCachePrune(ctx context.Context) (*types.BuildCachePruneReport, error)
 	ImageCreate(ctx context.Context, parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error)
-	ImageDelta(ctx context.Context, src, dest string) (io.ReadCloser, error)
+	ImageDelta(ctx context.Context, src, dest string, options types.ImageDeltaOptions) (io.ReadCloser, error)
 	ImageHistory(ctx context.Context, image string) ([]image.HistoryResponseItem, error)
 	ImageImport(ctx context.Context, source types.ImageImportSource, ref string, options types.ImageImportOptions) (io.ReadCloser, error)
 	ImageInspectWithRaw(ctx context.Context, image string) (types.ImageInspect, []byte, error)

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	containertypes "github.com/docker/docker/api/types/container"
 	networktypes "github.com/docker/docker/api/types/network"
@@ -275,7 +276,7 @@ func (daemon *Daemon) setRWLayer(container *container.Container, runtime string)
 	}
 
 	initFunc := daemon.getLayerInit()
-	if  runtime == "bare" {
+	if runtime == "bare" {
 		initFunc = nil
 	}
 
@@ -361,7 +362,7 @@ func verifyNetworkingConfig(nwConfig *networktypes.NetworkingConfig) error {
 
 // DeltaCreate creates a delta of the specified src and dest images
 // This is called directly from the Engine API
-func (daemon *Daemon) DeltaCreate(deltaSrc, deltaDest string, outStream io.Writer) error {
+func (daemon *Daemon) DeltaCreate(deltaSrc, deltaDest string, options types.ImageDeltaOptions, outStream io.Writer) error {
 	progressOutput := streamformatter.NewJSONProgressOutput(outStream, false)
 
 	srcImg, err := daemon.GetImage(deltaSrc)
@@ -566,5 +567,27 @@ func (daemon *Daemon) DeltaCreate(deltaSrc, deltaDest string, outStream io.Write
 
 	outStream.Write(streamformatter.FormatStatus("", "Normal size: %s, Delta size: %s, %.2fx improvement", humanTotal, humanDelta, deltaRatio))
 	outStream.Write(streamformatter.FormatStatus("", "Created delta: %s", id.String()))
+
+	if options.Tag == "" {
+		return nil
+	}
+
+	ref, err := reference.ParseNormalizedNamed(options.Tag)
+	if err != nil {
+		return err
+	}
+
+	if _, isCanonical := ref.(reference.Canonical); isCanonical {
+		return errors.New("build tag cannot contain a digest")
+	}
+
+	ref = reference.TagNameOnly(ref)
+
+	if err := daemon.TagImageWithReference(id, runtime.GOOS, ref); err != nil {
+		return err
+	}
+	logrus.Debugf("Tagged delta %s with %s", id.String(), reference.FamiliarString(ref))
+	outStream.Write(streamformatter.FormatStatus("", "Successfully tagged %s\n", reference.FamiliarString(ref)))
+
 	return nil
 }

--- a/integration/image/delta_test.go
+++ b/integration/image/delta_test.go
@@ -1,0 +1,72 @@
+package image
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	apiclient "github.com/docker/docker/client"
+)
+
+// TestDelta just creates a delta and checks if it exists
+func TestDelta(t *testing.T) {
+	var (
+		base   = "busybox:1.24"
+		target = "busybox:1.29"
+		delta  = "busybox:delta-1.24-1.29"
+	)
+
+	var (
+		err    error
+		rc     io.ReadCloser
+		ctx    = context.Background()
+		client = testEnv.APIClient()
+	)
+
+	pullBaseAndTargetImages(t, client, base, target)
+
+	rc, err = client.ImageDelta(ctx,
+		base,
+		target,
+		types.ImageDeltaOptions{
+			Tag: delta,
+		})
+	if err != nil {
+		t.Fatalf("Creating delta: %s", err)
+	}
+	io.Copy(ioutil.Discard, rc)
+	rc.Close()
+
+	_, _, err = client.ImageInspectWithRaw(ctx, delta)
+	if err != nil {
+		t.Fatalf("Inspecting delta: %s", err)
+	}
+}
+
+func pullBaseAndTargetImages(t *testing.T, client apiclient.APIClient, base, target string) {
+	var (
+		err error
+		rc  io.ReadCloser
+		ctx = context.Background()
+	)
+
+	rc, err = client.ImagePull(ctx,
+		base,
+		types.ImagePullOptions{})
+	if err != nil {
+		t.Fatalf("Pulling delta base: %s", err)
+	}
+	io.Copy(ioutil.Discard, rc)
+	rc.Close()
+
+	rc, err = client.ImagePull(ctx,
+		target,
+		types.ImagePullOptions{})
+	if err != nil {
+		t.Fatalf("Pulling delta target: %s", err)
+	}
+	io.Copy(ioutil.Discard, rc)
+	rc.Close()
+}


### PR DESCRIPTION
Similar to how the build command allows tagging of images this allows
specifying a repo:tag indentifier to tag the delta with

Change-type: minor
Signed-off-by: Robert Günzler <robertg@balena.io>