### PR TITLE
Add cli for tagging delta images

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -143,7 +143,7 @@ github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 github.com/Nvveen/Gotty a8b993ba6abdb0e0c12b0125c603323a71c7790c https://github.com/ijc25/Gotty
 
 # docker CLI
-github.com/docker/cli ce80489d66dfc63ac005f55f5bdca2f03abee6e9 https://github.com/resin-os/balena-cli
+github.com/docker/cli 3ea974fbc0ce5a0bf0764577886532ece41cd7aa https://github.com/resin-os/balena-cli
 github.com/mitchellh/mapstructure f3009df150dadf309fdee4a54ed65c124afad715
 gopkg.in/yaml.v2 4c78c975fe7c825c6d1466c42be594d1d6f3aba6
 github.com/docker/docker-credential-helpers 3c90bd29a46b943b2a9842987b58fb91a7c1819b

--- a/vendor/github.com/docker/cli/cli/command/image/delta.go
+++ b/vendor/github.com/docker/cli/cli/command/image/delta.go
@@ -3,6 +3,7 @@ package image
 import (
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
@@ -11,11 +12,12 @@ import (
 type deltaOptions struct {
 	src  string
 	dest string
+	tag  string
 }
 
 // NewDeltaCommand creates a new `docker delta` command
 func NewDeltaCommand(dockerCli command.Cli) *cobra.Command {
-	var options deltaOptions
+	var options = deltaOptions{}
 
 	cmd := &cobra.Command{
 		Use:   "delta [OPTIONS] SRC_IMAGE DEST_IMAGE",
@@ -28,13 +30,21 @@ func NewDeltaCommand(dockerCli command.Cli) *cobra.Command {
 		},
 	}
 
+	flags := cmd.Flags()
+	flags.StringVar(&options.tag, "tag", "t", "Name and optionally a tag in the 'name:tag' format")
+	command.AddTrustVerificationFlags(flags)
+
 	return cmd
 }
 
 func runDelta(dockerCli command.Cli, options deltaOptions) error {
 	clnt := dockerCli.Client()
 
-	responseBody, err := clnt.ImageDelta(context.Background(), options.src, options.dest)
+	deltaOpts := types.ImageDeltaOptions{
+		Tag: options.tag,
+	}
+
+	responseBody, err := clnt.ImageDelta(context.Background(), options.src, options.dest, deltaOpts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Update vendor.conf and vendor/ to include https://github.com/balena-os/balena-engine-cli/pull/7

Change-type: patch
Signed-off-by: Robert Günzler <robertg@balena.io>