### PR TITLE
Update balena.service

### DIFF
--- a/contrib/init/systemd/balena-engine.service
+++ b/contrib/init/systemd/balena-engine.service
@@ -10,7 +10,7 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/balena-engine-daemon -H fd://
+ExecStart=/usr/local/bin/balena-engine-daemon -H fd://
 ExecReload=/bin/kill -s HUP $MAINPID
 LimitNOFILE=1048576
 # Having non-zero Limit*s causes performance problems due to accounting overhead


### PR DESCRIPTION
changes:
ExecStart - 1) change executable path since install.sh puts it in different path 2) remove -H flag since it causes an error
TasksMax - Uncommented by default
TimeoutStartSec - Deleted, it causes an error

Tested on ubuntu 16.04 arch arm64