### PR TITLE
travis: use minimal image and stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: minimal
 
-branches:
-  except:
-    - gh-pages
-    - /^(.*)-build-[a-f0-9]{40}$/
+# only run for non-push actions
+# with the exception of master and version branches
+if: type != push OR branch = master OR branch =~ /^\d{2}\.\d{2}-(.*)$/
 
 sudo: required
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
-language: go
-go:
-  - 1.10.4
-  # - 1.11.4
+language: minimal
 
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,42 @@ sudo: required
 services:
   - docker
 
+stages:
+  - test
+  - build
+
 before_install:
   - docker version
 
-before_script:
-  # prevent legacy integration tests from running to not exeed travis job time limit
-  - sed -i -e '/run_test_integration_legacy_suites$/ s/^/#/' hack/make/.integration-test-helpers
+jobs:
+  include:
+    - stage: test
+      name: "Unit tests"
+      script:
+        - make test-unit
 
-script:
-  - make test-unit
-  - make test-integration
-  - docker build -f Dockerfile.build.x86_64 -t balena-engine-build-x86_64 .
-  - docker run --rm -v "$(pwd):/balena-engine" balena-engine-build-x86_64 ./build.sh
+    - stage: test
+      name: "Integration tests"
+      before_script:
+        # prevent legacy integration tests from running to not exeed travis job time limit
+        - sed -i -e '/run_test_integration_legacy_suites$/ s/^/#/' hack/make/.integration-test-helpers
+      script:
+        - make test-integration
+
+    - stage: build
+      name: "Build for x86_64"
+      script:
+        - docker build -f Dockerfile.build.x86_64 -t balena-engine-build-x86_64 .
+        - docker run --rm -v "$(pwd):/balena-engine" balena-engine-build-x86_64 ./build.sh
+
+    - stage: build
+      name: "Build for armv7"
+      script:
+        - docker build -f Dockerfile.build.arm -t balena-engine-build-arm .
+        - travis_wait 30 docker run --rm -e GOARM=7 -v "$(pwd):/balena-engine" balena-engine-build-arm /bin/sh build.sh
+
+    - stage: build
+      name: "Build for aarch64"
+      script:
+        - docker build -f Dockerfile.build.aarch64 -t balena-engine-build-aarch64 .
+        - travis_wait 30 docker run --rm -v "$(pwd):/balena-engine" balena-engine-build-aarch64 /bin/sh build.sh


### PR DESCRIPTION
Since we build in docker anyway we can save the time it usually takes to
set up the Go environment.
See: https://docs.travis-ci.com/user/languages/minimal-and-generic/

Signed-off-by: Robert Günzler <robertg@balena.io>