### PR TITLE
vendor: Update runc to include fix for CVE-2019-5736

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -63,7 +63,7 @@ github.com/pborman/uuid v1.0
 google.golang.org/grpc v1.3.0
 
 # When updating, also update RUNC_COMMIT in hack/dockerfile/binaries-commits accordingly
-github.com/opencontainers/runc 663abfe04156311a2683ae6f7e2e195dd81cd023 https://github.com/resin-os/balena-runc
+github.com/opencontainers/runc 2da76ff5ab211259723c0a0397e896fdb2ff6969 https://github.com/resin-os/balena-runc
 github.com/opencontainers/runtime-spec v1.0.0
 github.com/opencontainers/image-spec v1.0.0
 github.com/seccomp/libseccomp-golang 32f571b70023028bd57d9288c20efbcb237f3ce0

--- a/vendor/github.com/opencontainers/runc/libcontainer/nsenter/cloned_binary.c
+++ b/vendor/github.com/opencontainers/runc/libcontainer/nsenter/cloned_binary.c
@@ -1,0 +1,268 @@
+/*
+ * Copyright (C) 2019 Aleksa Sarai <cyphar@cyphar.com>
+ * Copyright (C) 2019 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <limits.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/vfs.h>
+#include <sys/mman.h>
+#include <sys/sendfile.h>
+#include <sys/syscall.h>
+
+/* Use our own wrapper for memfd_create. */
+#if !defined(SYS_memfd_create) && defined(__NR_memfd_create)
+#  define SYS_memfd_create __NR_memfd_create
+#endif
+#ifdef SYS_memfd_create
+#  define HAVE_MEMFD_CREATE
+/* memfd_create(2) flags -- copied from <linux/memfd.h>. */
+#  ifndef MFD_CLOEXEC
+#    define MFD_CLOEXEC       0x0001U
+#    define MFD_ALLOW_SEALING 0x0002U
+#  endif
+int memfd_create(const char *name, unsigned int flags)
+{
+	return syscall(SYS_memfd_create, name, flags);
+}
+#endif
+
+/* This comes directly from <linux/fcntl.h>. */
+#ifndef F_LINUX_SPECIFIC_BASE
+#  define F_LINUX_SPECIFIC_BASE 1024
+#endif
+#ifndef F_ADD_SEALS
+#  define F_ADD_SEALS (F_LINUX_SPECIFIC_BASE + 9)
+#  define F_GET_SEALS (F_LINUX_SPECIFIC_BASE + 10)
+#endif
+#ifndef F_SEAL_SEAL
+#  define F_SEAL_SEAL   0x0001	/* prevent further seals from being set */
+#  define F_SEAL_SHRINK 0x0002	/* prevent file from shrinking */
+#  define F_SEAL_GROW   0x0004	/* prevent file from growing */
+#  define F_SEAL_WRITE  0x0008	/* prevent writes */
+#endif
+
+#define RUNC_SENDFILE_MAX 0x7FFFF000 /* sendfile(2) is limited to 2GB. */
+#ifdef HAVE_MEMFD_CREATE
+#  define RUNC_MEMFD_COMMENT "runc_cloned:/proc/self/exe"
+#  define RUNC_MEMFD_SEALS \
+	(F_SEAL_SEAL | F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE)
+#endif
+
+static void *must_realloc(void *ptr, size_t size)
+{
+	void *old = ptr;
+	do {
+		ptr = realloc(old, size);
+	} while(!ptr);
+	return ptr;
+}
+
+/*
+ * Verify whether we are currently in a self-cloned program (namely, is
+ * /proc/self/exe a memfd). F_GET_SEALS will only succeed for memfds (or rather
+ * for shmem files), and we want to be sure it's actually sealed.
+ */
+static int is_self_cloned(void)
+{
+	int fd, ret, is_cloned = 0;
+
+	fd = open("/proc/self/exe", O_RDONLY|O_CLOEXEC);
+	if (fd < 0)
+		return -ENOTRECOVERABLE;
+
+#ifdef HAVE_MEMFD_CREATE
+	ret = fcntl(fd, F_GET_SEALS);
+	is_cloned = (ret == RUNC_MEMFD_SEALS);
+#else
+	struct stat statbuf = {0};
+	ret = fstat(fd, &statbuf);
+	if (ret >= 0)
+		is_cloned = (statbuf.st_nlink == 0);
+#endif
+	close(fd);
+	return is_cloned;
+}
+
+/*
+ * Basic wrapper around mmap(2) that gives you the file length so you can
+ * safely treat it as an ordinary buffer. Only gives you read access.
+ */
+static char *read_file(char *path, size_t *length)
+{
+	int fd;
+	char buf[4096], *copy = NULL;
+
+	if (!length)
+		return NULL;
+
+	fd = open(path, O_RDONLY | O_CLOEXEC);
+	if (fd < 0)
+		return NULL;
+
+	*length = 0;
+	for (;;) {
+		int n;
+
+		n = read(fd, buf, sizeof(buf));
+		if (n < 0)
+			goto error;
+		if (!n)
+			break;
+
+		copy = must_realloc(copy, (*length + n) * sizeof(*copy));
+		memcpy(copy + *length, buf, n);
+		*length += n;
+	}
+	close(fd);
+	return copy;
+
+error:
+	close(fd);
+	free(copy);
+	return NULL;
+}
+
+/*
+ * A poor-man's version of "xargs -0". Basically parses a given block of
+ * NUL-delimited data, within the given length and adds a pointer to each entry
+ * to the array of pointers.
+ */
+static int parse_xargs(char *data, int data_length, char ***output)
+{
+	int num = 0;
+	char *cur = data;
+
+	if (!data || *output != NULL)
+		return -1;
+
+	while (cur < data + data_length) {
+		num++;
+		*output = must_realloc(*output, (num + 1) * sizeof(**output));
+		(*output)[num - 1] = cur;
+		cur += strlen(cur) + 1;
+	}
+	(*output)[num] = NULL;
+	return num;
+}
+
+/*
+ * "Parse" out argv and envp from /proc/self/cmdline and /proc/self/environ.
+ * This is necessary because we are running in a context where we don't have a
+ * main() that we can just get the arguments from.
+ */
+static int fetchve(char ***argv, char ***envp)
+{
+	char *cmdline = NULL, *environ = NULL;
+	size_t cmdline_size, environ_size;
+
+	cmdline = read_file("/proc/self/cmdline", &cmdline_size);
+	if (!cmdline)
+		goto error;
+	environ = read_file("/proc/self/environ", &environ_size);
+	if (!environ)
+		goto error;
+
+	if (parse_xargs(cmdline, cmdline_size, argv) <= 0)
+		goto error;
+	if (parse_xargs(environ, environ_size, envp) <= 0)
+		goto error;
+
+	return 0;
+
+error:
+	free(environ);
+	free(cmdline);
+	return -EINVAL;
+}
+
+static int clone_binary(void)
+{
+	int binfd, memfd;
+	ssize_t sent = 0;
+
+#ifdef HAVE_MEMFD_CREATE
+	memfd = memfd_create(RUNC_MEMFD_COMMENT, MFD_CLOEXEC | MFD_ALLOW_SEALING);
+#else
+	memfd = open("/tmp", O_TMPFILE | O_EXCL | O_RDWR | O_CLOEXEC, 0711);
+#endif
+	if (memfd < 0)
+		return -ENOTRECOVERABLE;
+
+	binfd = open("/proc/self/exe", O_RDONLY | O_CLOEXEC);
+	if (binfd < 0)
+		goto error;
+
+	sent = sendfile(memfd, binfd, NULL, RUNC_SENDFILE_MAX);
+	close(binfd);
+	if (sent < 0)
+		goto error;
+
+#ifdef HAVE_MEMFD_CREATE
+	int err = fcntl(memfd, F_ADD_SEALS, RUNC_MEMFD_SEALS);
+	if (err < 0)
+		goto error;
+#else
+	/* Need to re-open "memfd" as read-only to avoid execve(2) giving -EXTBUSY. */
+	int newfd;
+	char *fdpath = NULL;
+
+	if (asprintf(&fdpath, "/proc/self/fd/%d", memfd) < 0)
+		goto error;
+	newfd = open(fdpath, O_RDONLY | O_CLOEXEC);
+	free(fdpath);
+	if (newfd < 0)
+		goto error;
+
+	close(memfd);
+	memfd = newfd;
+#endif
+	return memfd;
+
+error:
+	close(memfd);
+	return -EIO;
+}
+
+int ensure_cloned_binary(void)
+{
+	int execfd;
+	char **argv = NULL, **envp = NULL;
+
+	/* Check that we're not self-cloned, and if we are then bail. */
+	int cloned = is_self_cloned();
+	if (cloned > 0 || cloned == -ENOTRECOVERABLE)
+		return cloned;
+
+	if (fetchve(&argv, &envp) < 0)
+		return -EINVAL;
+
+	execfd = clone_binary();
+	if (execfd < 0)
+		return -EIO;
+
+	fexecve(execfd, argv, envp);
+	return -ENOEXEC;
+}

--- a/vendor/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c
+++ b/vendor/github.com/opencontainers/runc/libcontainer/nsenter/nsexec.c
@@ -528,6 +528,9 @@ void join_namespaces(char *nslist)
 	free(namespaces);
 }
 
+/* Defined in cloned_binary.c. */
+extern int ensure_cloned_binary(void);
+
 void nsexec(void)
 {
 	int pipenum;
@@ -542,6 +545,14 @@ void nsexec(void)
 	pipenum = initpipe();
 	if (pipenum == -1)
 		return;
+
+	/*
+	 * We need to re-exec if we are not in a cloned binary. This is necessary
+	 * to ensure that containers won't be able to access the host binary
+	 * through /proc/self/exe. See CVE-2019-5736.
+	 */
+	if (ensure_cloned_binary() < 0)
+		bail("could not ensure we are a cloned binary");
 
 	/* Parse all of the netlink configuration. */
 	nl_parse(pipenum, &config);


### PR DESCRIPTION
Tested on Raspberry Pi 3 with balenaOS 2.29.2+rev2

<details>

```
+ balena-engine --version
balena-engine version 17.12.0-dev, build dceb2fc48071b78a8a828e0468a15a479515385f

+ balena info
+ grep -i 'Default Runtime'
Default Runtime: runc

+ balena ps
CONTAINER ID        IMAGE                              COMMAND                  CREATED             STATUS                   PORTS               NAMES
c2117e3059d3        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About an hour ago   Up 5 seconds                                 cve-mem-test_work_1
caa1f5b3e988        balena/armv7hf-supervisor:v9.0.1   "./entry.sh"             4 hours ago         Up 8 minutes (healthy)                       resin_supervisor

+ systemd-cgtop -n1
+ head -n 5
/                                                                                                 42      -   504.7M        -        -
/docker                                                                                            -      -    26.1M        -        -
/docker/c2117e3059d375f145ecedbcec3a80588dcade95cca8f33f186af6d4f481c89b                           -      -  1012.0K        -        -
/docker/caa1f5b3e988bde4ae35d2ab01af4e40b66a9f3eb714bf6fee0e4b79728f6ac3                           -      -    25.1M        -        -
/init.scope                                                                                        1      -        -        -        -

+ balena ps
CONTAINER ID        IMAGE                              COMMAND                  CREATED              STATUS                   PORTS               NAMES
a13948998c32        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 10 seconds                                cve-mem-test_work_5
988690d65bea        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 11 seconds                                cve-mem-test_work_7
22af2e7ab5aa        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 17 seconds                                cve-mem-test_work_8
42756c18bbb9        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 19 seconds                                cve-mem-test_work_10
63af4ef52b30        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 27 seconds                                cve-mem-test_work_2
57e4cfd34f39        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 34 seconds                                cve-mem-test_work_9
81820db3be8c        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 15 seconds                                cve-mem-test_work_6
75d81a7fc156        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 45 seconds                                cve-mem-test_work_3
a19a75f197cd        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 49 seconds                                cve-mem-test_work_4
c2117e3059d3        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About an hour ago    Up About a minute                            cve-mem-test_work_1
caa1f5b3e988        balena/armv7hf-supervisor:v9.0.1   "./entry.sh"             4 hours ago          Up 6 minutes (healthy)                       resin_supervisor

+ systemd-cgtop -n1
+ head -n 14
/                                                                                                 69      -   531.0M        -        -
/docker                                                                                            -      -    32.7M        -        -
/docker/22af2e7ab5aa4cb56a30ce55543f54bf40f8073cdd4dab6ba51f86bb1777de94                           -      -   672.0K        -        -
/docker/42756c18bbb99b77d9ca3a3dfadc85582f7fae8f0dfbb19d86412317567be49d                           -      -   696.0K        -        -
/docker/57e4cfd34f39d5a94e072919b700f838d84ade1edee1e62f346a931f81081660                           -      -   836.0K        -        -
/docker/63af4ef52b30560644aadd3e7b1e59dc9ff4c44688cd8ff71a5d382f621e185a                           -      -   712.0K        -        -
/docker/75d81a7fc156492e29f6fe8aa70642ff988d13474a2c89ef9c602ca5821545ba                           -      -   724.0K        -        -
/docker/81820db3be8c68d8da6719740a4dd6f86739090eff94a2f03e360c041b3a9a48                           -      -   780.0K        -        -
/docker/988690d65bea19e44649e63aea67365ce6542eb2f3a35ce9ef9515cc8d0ee600                           -      -   932.0K        -        -
/docker/a13948998c32521f1d184a9a33fc3c643e7dec5c9077573664c0e0ac1796a683                           -      -   884.0K        -        -
/docker/a19a75f197cd39ac3fd928e6e7968f3b9bfc3471cda1a481c9b07feab96fdc83                           -      -   664.0K        -        -
/docker/c2117e3059d375f145ecedbcec3a80588dcade95cca8f33f186af6d4f481c89b                           -      -   904.0K        -        -
/docker/caa1f5b3e988bde4ae35d2ab01af4e40b66a9f3eb714bf6fee0e4b79728f6ac3                           -      -    25.1M        -        -
/init.scope                                                                                        1      -        -        -        -

```

Configuring balenaEngine with the patched runc 
```
+ balena-engine --version
balena-engine version 17.12.0-dev, build dceb2fc48071b78a8a828e0468a15a479515385f

+ balena info
+ grep -i 'Default Runtime'
Default Runtime: runc-cve

+ balena ps
CONTAINER ID        IMAGE                              COMMAND                  CREATED             STATUS                            PORTS               NAMES
c2117e3059d3        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About an hour ago   Up 3 minutes                                          cve-mem-test_work_1
caa1f5b3e988        balena/armv7hf-supervisor:v9.0.1   "./entry.sh"             4 hours ago         Up 4 minutes (health: starting)                       resin_supervisor

+ systemd-cgtop -n1
+ head -n 5
/                                                                                                 42      -   516.8M        -        -
/docker                                                                                            -      -    78.3M        -        -
/docker/c2117e3059d375f145ecedbcec3a80588dcade95cca8f33f186af6d4f481c89b                           -      -   960.0K        -        -
/docker/caa1f5b3e988bde4ae35d2ab01af4e40b66a9f3eb714bf6fee0e4b79728f6ac3                           -      -    77.4M        -        -
/init.scope                                                                                        1      -        -        -        -

+ balena ps
CONTAINER ID        IMAGE                              COMMAND                  CREATED              STATUS                   PORTS               NAMES
c104db6c8d2c        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 27 seconds                                cve-mem-test_work_8
a42e2c352a8c        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 31 seconds                                cve-mem-test_work_3
0ee0e4bde92a        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 29 seconds                                cve-mem-test_work_6
494c6d40b1fa        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 34 seconds                                cve-mem-test_work_9
478928f61a83        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 34 seconds                                cve-mem-test_work_2
43f639d08fe3        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 38 seconds                                cve-mem-test_work_7
45d158f9434e        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 41 seconds                                cve-mem-test_work_10
1c04683968f5        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 59 seconds                                cve-mem-test_work_5
784ff8c4d6a6        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About a minute ago   Up 55 seconds                                cve-mem-test_work_4
c2117e3059d3        cve-mem-test_work                  "/usr/bin/entry.sh /…"   About an hour ago    Up About a minute                            cve-mem-test_work_1
caa1f5b3e988        balena/armv7hf-supervisor:v9.0.1   "./entry.sh"             4 hours ago          Up 7 minutes (healthy)                       resin_supervisor

+ systemd-cgtop -n1
+ head -n 14
/                                                                                                 72      -   544.3M        -        -
/docker                                                                                            -      -    69.4M        -        -
/docker/0ee0e4bde92acc2989d974e81fcbf21d277b127df3b4d4f661fac8434e92f95d                           -      -   888.0K        -        -
/docker/1c04683968f5c30ef8350df857dddd477df68d57a3fda0cd07962eb94f741fbb                           -      -   948.0K        -        -
/docker/43f639d08fe306d21d5573a1e0bca2bf6ab30362f730ff0fb27560444eb482fd                           -      -   908.0K        -        -
/docker/45d158f9434e3d56ed047d2176d65dd6e8d5b0f13c789b16dc52c3409f6fece0                           -      -   844.0K        -        -
/docker/478928f61a831a5502febb642d306595bb92ff768ead542617a6466ffc910e11                           -      -   896.0K        -        -
/docker/494c6d40b1facde9d09ce3a69860af55d33758cbc4ee375028db19305a5a5c7e                           -      -   876.0K        -        -
/docker/784ff8c4d6a64c8583f7891a54118470a369359e0e8cc9d5c2f205137c52829a                           -      -   932.0K        -        -
/docker/a42e2c352a8ceda4cdff581c164f627afeed0577e05e133cab15f5ab68872efa                           -      -   816.0K        -        -
/docker/c104db6c8d2c55590963504948b144a4f3844d5566608ee844698bcacbe4d844                           -      -   928.0K        -        -
/docker/c2117e3059d375f145ecedbcec3a80588dcade95cca8f33f186af6d4f481c89b                           -      -  1000.0K        -        -
/docker/caa1f5b3e988bde4ae35d2ab01af4e40b66a9f3eb714bf6fee0e4b79728f6ac3                           -      -    60.6M        -        -
/init.scope                                                                                        1      -        -        -        -
```

</details>

---

In both cases I see a memory increase of ~30MB when increasing the container count from 1 to 10 replicas of the test application.

Edit:

My method of testing above doesn't really show the memory hit we get from running the patch, since that only appears when starting the container and I was measuring later in the container lifecycle.

```
$ balena run --memory=23m busybox cat /etc/hostname
```

The memory limit applied here has to be at or slightly higher than the size of the runc binary: ~23-25 MB for our single balenaEngine vs ~10 MB for standalone runc.