### PR TITLE
Allow to turn off fs syncing on every layer diff for aufs/overlay2 storage drivers

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -32,6 +32,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -45,6 +46,7 @@ import (
 	"github.com/docker/docker/pkg/idtools"
 	"github.com/docker/docker/pkg/locker"
 	mountpk "github.com/docker/docker/pkg/mount"
+	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/system"
 	rsystem "github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -82,11 +84,17 @@ type Driver struct {
 	pathCache     map[string]string
 	naiveDiff     graphdriver.DiffDriver
 	locker        *locker.Locker
+	syncDiffs     bool
 }
 
 // Init returns a new AUFS driver.
 // An error is returned if AUFS is not supported.
 func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
+	syncDiffs, err := parseOptions(options)
+	if err != nil {
+		return nil, err
+	}
+
 	// Try to load the aufs kernel module
 	if err := supportsAufs(); err != nil {
 		logger.Error(err)
@@ -129,6 +137,7 @@ func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		pathCache: make(map[string]string),
 		ctr:       graphdriver.NewRefCounter(graphdriver.NewFsChecker(graphdriver.FsMagicAufs)),
 		locker:    locker.New(),
+		syncDiffs: syncDiffs,
 	}
 
 	rootUID, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)
@@ -167,8 +176,30 @@ func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		}
 	}
 
+	logger.Debugf("syncDiffs=%v", syncDiffs)
 	a.naiveDiff = graphdriver.NewNaiveDiffDriver(a, uidMaps, gidMaps)
 	return a, nil
+}
+
+func parseOptions(options []string) (bool, error) {
+	var o bool = true
+	for _, option := range options {
+		key, val, err := parsers.ParseKeyValueOpt(option)
+		if err != nil {
+			return o, err
+		}
+		key = strings.ToLower(key)
+		switch key {
+		case "aufs.sync_diffs":
+			o, err = strconv.ParseBool(val)
+			if err != nil {
+				return o, err
+			}
+		default:
+			return o, fmt.Errorf("aufs: unknown option %s", key)
+		}
+	}
+	return o, nil
 }
 
 // Return a nil error if the kernel supports aufs
@@ -514,9 +545,11 @@ func (a *Driver) ApplyDiff(id, parent string, diff io.Reader) (size int64, err e
 		return
 	}
 
-	// FIXME: Instead of syncing all the filesystems we should be fsyncing each
-	// file as the tar archive gets unpacked
-	syscall.Sync()
+	if a.syncDiffs {
+		// FIXME: Instead of syncing all the filesystems we should be fsyncing each
+		// file as the tar archive gets unpacked
+		syscall.Sync()
+	}
 
 	return a.DiffSize(id, parent)
 }

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -90,6 +90,7 @@ const (
 type overlayOptions struct {
 	overrideKernelCheck bool
 	quota               quota.Quota
+	syncDiffs           bool
 }
 
 // Driver contains information about the home directory and the list of active
@@ -241,13 +242,13 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		logger.Warnf("Unable to detect whether overlay kernel module supports index parameter: %s", err)
 	}
 
-	logger.Debugf("backingFs=%s, projectQuotaSupported=%v, indexOff=%q", backingFs, projectQuotaSupported, indexOff)
+	logger.Debugf("backingFs=%s, projectQuotaSupported=%v, indexOff=%q, syncDiffs=%v", backingFs, projectQuotaSupported, indexOff, opts.syncDiffs)
 
 	return d, nil
 }
 
 func parseOptions(options []string) (*overlayOptions, error) {
-	o := &overlayOptions{}
+	o := &overlayOptions{syncDiffs: true}
 	for _, option := range options {
 		key, val, err := parsers.ParseKeyValueOpt(option)
 		if err != nil {
@@ -266,6 +267,11 @@ func parseOptions(options []string) (*overlayOptions, error) {
 				return nil, err
 			}
 			o.quota.Size = uint64(size)
+		case "overlay2.sync_diffs":
+			o.syncDiffs, err = strconv.ParseBool(val)
+			if err != nil {
+				return nil, err
+			}
 		default:
 			return nil, fmt.Errorf("overlay2: unknown option %s", key)
 		}
@@ -727,9 +733,11 @@ func (d *Driver) ApplyDiff(id string, parent string, diff io.Reader) (size int64
 		return 0, err
 	}
 
-	// FIXME: Instead of syncing all the filesystems we should be fsyncing each
-	// file as the tar archive gets unpacked
-	syscall.Sync()
+	if d.options.syncDiffs {
+		// FIXME: Instead of syncing all the filesystems we should be fsyncing each
+		// file as the tar archive gets unpacked
+		syscall.Sync()
+	}
 
 	return directory.Size(context.TODO(), applyDir)
 }

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -18,6 +18,7 @@ func TestImagePullComparePullDuration(t *testing.T) {
 
 	for _, storageDriver := range []string{"aufs", "overlay2"} {
 		t.Run(fmt.Sprintf("storageDriver=%s", storageDriver), func(t *testing.T) {
+			skip.If(t, storageDriver == "aufs", "Aufs doesn't work with dind")
 
 			var (
 				durSync, durNoSync time.Duration

--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -1,0 +1,56 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/internal/test/daemon"
+
+	"gotest.tools/assert"
+	"gotest.tools/skip"
+)
+
+func TestImagePullComparePullDuration(t *testing.T) {
+	skip.If(t, testEnv.IsRemoteDaemon())
+
+	for _, storageDriver := range []string{"aufs", "overlay2"} {
+		t.Run(fmt.Sprintf("storageDriver=%s", storageDriver), func(t *testing.T) {
+
+			var (
+				durSync, durNoSync time.Duration
+				args               = []string{fmt.Sprintf("--storage-driver=%s", storageDriver)}
+				testImage          = "balenalib/amd64-debian:build" // should have a few layers so it actually has an impact on pull performance
+			)
+
+			d := daemon.New(t)
+			client, err := d.NewClient()
+			assert.NilError(t, err)
+
+			d.Start(t, append(args, []string{fmt.Sprintf("--storage-opt=%s.sync_diffs=true", storageDriver)}...)...)
+			info := d.Info(t)
+			assert.Equal(t, info.Driver, storageDriver)
+
+			ctx := context.Background()
+			start := time.Now()
+			_, err = client.ImagePull(ctx, testImage, types.ImagePullOptions{})
+			durSync = time.Now().Sub(start)
+			t.Logf("%s/syncDiffs=true took %s", t.Name(), durSync)
+			assert.NilError(t, err)
+
+			d.Stop(t)
+			d.Start(t, append(args, []string{fmt.Sprintf("--storage-opt=%s.sync_diffs=false", storageDriver)}...)...)
+			defer d.Stop(t)
+
+			start = time.Now()
+			_, err = client.ImagePull(ctx, testImage, types.ImagePullOptions{})
+			durNoSync = time.Now().Sub(start)
+			t.Logf("%s/syncDiffs=false took %s", t.Name(), durNoSync)
+			assert.NilError(t, err)
+
+			assert.Assert(t, durSync > durNoSync)
+		})
+	}
+}


### PR DESCRIPTION
This patch adds a driver option to enalble/disable the to disk syncing introduced in
684d8ba.

The default is still to sync all currently mounted filesystems before
reporting an ApplyDiff as successful.

Connects-to: #133 