### PR TITLE
Add daemon flags to configure max download/upload attempts during pull/push

### DIFF
--- a/cmd/dockerd/config.go
+++ b/cmd/dockerd/config.go
@@ -19,6 +19,7 @@ const (
 // installCommonConfigFlags adds flags to the pflag.FlagSet to configure the daemon
 func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	var maxConcurrentDownloads, maxConcurrentUploads int
+	var maxDownloadAttempts, maxUploadAttempts int
 
 	installRegistryServiceFlags(&conf.ServiceOptions, flags)
 
@@ -62,6 +63,8 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 	flags.StringVar(&conf.CorsHeaders, "api-cors-header", "", "Set CORS headers in the Engine API")
 	flags.IntVar(&maxConcurrentDownloads, "max-concurrent-downloads", config.DefaultMaxConcurrentDownloads, "Set the max concurrent downloads for each pull")
 	flags.IntVar(&maxConcurrentUploads, "max-concurrent-uploads", config.DefaultMaxConcurrentUploads, "Set the max concurrent uploads for each push")
+	flags.IntVar(&maxDownloadAttempts, "max-download-attempts", config.DefaultMaxDownloadAttempts, "Set the max download attempts for each pull")
+	flags.IntVar(&maxUploadAttempts, "max-upload-attempts", config.DefaultMaxUploadAttempts, "Set the max upload attempts for each push")
 	flags.IntVar(&conf.ShutdownTimeout, "shutdown-timeout", defaultShutdownTimeout, "Set the default shutdown timeout")
 	flags.IntVar(&conf.NetworkDiagnosticPort, "network-diagnostic-port", 0, "TCP port number of the network diagnostic server")
 	flags.MarkHidden("network-diagnostic-port")
@@ -83,6 +86,8 @@ func installCommonConfigFlags(conf *config.Config, flags *pflag.FlagSet) {
 
 	conf.MaxConcurrentDownloads = &maxConcurrentDownloads
 	conf.MaxConcurrentUploads = &maxConcurrentUploads
+	conf.MaxDownloadAttempts = &maxDownloadAttempts
+	conf.MaxUploadAttempts = &maxUploadAttempts
 }
 
 func installRegistryServiceFlags(options *registry.ServiceOptions, flags *pflag.FlagSet) {

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -32,6 +32,14 @@ const (
 	// maximum number of uploads that
 	// may take place at a time for each push.
 	DefaultMaxConcurrentUploads = 5
+	// DefaultMaxDownloadAttempts is the default value for
+	// maximum number of times that
+	// a download may be retried during pull.
+	DefaultMaxDownloadAttempts = 5
+	// DefaultMaxUploadAttempts is the default value for
+	// maximum number of times that
+	// an upload may be retried during push.
+	DefaultMaxUploadAttempts = 5
 	// StockRuntimeName is the reserved name/alias used to represent the
 	// OCI runtime being shipped with the docker daemon package.
 	StockRuntimeName = "runc"
@@ -169,6 +177,14 @@ type CommonConfig struct {
 	// MaxConcurrentUploads is the maximum number of uploads that
 	// may take place at a time for each push.
 	MaxConcurrentUploads *int `json:"max-concurrent-uploads,omitempty"`
+
+	// MaxDownloadAttempts is the maximum number of times that failling downloads
+	// will be retried for each pull.
+	MaxDownloadAttempts *int `json:"max-download-attempts,omitempty"`
+
+	// MaxUploadAttempts is the maximum number of times that failling uploads
+	// will be retried for each push.
+	MaxUploadAttempts *int `json:"max-upload-attempts,omitempty"`
 
 	// ShutdownTimeout is the timeout value (in seconds) the daemon will wait for the container
 	// to stop when daemon is being shutdown
@@ -561,6 +577,14 @@ func Validate(config *Config) error {
 	// validate MaxConcurrentUploads
 	if config.MaxConcurrentUploads != nil && *config.MaxConcurrentUploads < 0 {
 		return fmt.Errorf("invalid max concurrent uploads: %d", *config.MaxConcurrentUploads)
+	}
+	// validate MaxDownloadAttempts
+	if config.MaxDownloadAttempts != nil && *config.MaxDownloadAttempts < 1 {
+		return fmt.Errorf("invalid max download attempts: %d", *config.MaxDownloadAttempts)
+	}
+	// validate MaxUploadAttempts
+	if config.MaxUploadAttempts != nil && *config.MaxUploadAttempts < 1 {
+		return fmt.Errorf("invalid max upload attempts: %d", *config.MaxUploadAttempts)
 	}
 
 	// validate that "default" runtime is not reset

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1008,6 +1008,8 @@ func NewDaemon(ctx context.Context, config *config.Config, pluginStore *plugin.S
 		DeltaStore:                deltaStore,
 		MaxConcurrentDownloads:    *config.MaxConcurrentDownloads,
 		MaxConcurrentUploads:      *config.MaxConcurrentUploads,
+		MaxDownloadAttempts:       *config.MaxDownloadAttempts,
+		MaxUploadAttempts:         *config.MaxUploadAttempts,
 		ReferenceStore:            rs,
 		RegistryService:           registryService,
 		TrustKey:                  trustKey,

--- a/daemon/images/service.go
+++ b/daemon/images/service.go
@@ -39,6 +39,8 @@ type ImageServiceConfig struct {
 	DeltaStore                image.Store
 	MaxConcurrentDownloads    int
 	MaxConcurrentUploads      int
+	MaxDownloadAttempts       int
+	MaxUploadAttempts         int
 	ReferenceStore            dockerreference.Store
 	RegistryService           registry.Service
 	TrustKey                  libtrust.PrivateKey
@@ -48,10 +50,12 @@ type ImageServiceConfig struct {
 func NewImageService(config ImageServiceConfig) *ImageService {
 	logrus.Debugf("Max Concurrent Downloads: %d", config.MaxConcurrentDownloads)
 	logrus.Debugf("Max Concurrent Uploads: %d", config.MaxConcurrentUploads)
+	logrus.Debugf("Max Download Attempts: %d", config.MaxDownloadAttempts)
+	logrus.Debugf("Max Uploads Attempts: %d", config.MaxUploadAttempts)
 	return &ImageService{
 		containers:                config.ContainerStore,
 		distributionMetadataStore: config.DistributionMetadataStore,
-		downloadManager:           xfer.NewLayerDownloadManager(config.LayerStores, config.MaxConcurrentDownloads),
+		downloadManager:           xfer.NewLayerDownloadManager(config.LayerStores, config.MaxConcurrentDownloads, config.MaxDownloadAttempts),
 		eventsService:             config.EventsService,
 		imageStore:                config.ImageStore,
 		layerStores:               config.LayerStores,
@@ -59,7 +63,7 @@ func NewImageService(config ImageServiceConfig) *ImageService {
 		referenceStore:            config.ReferenceStore,
 		registryService:           config.RegistryService,
 		trustKey:                  config.TrustKey,
-		uploadManager:             xfer.NewLayerUploadManager(config.MaxConcurrentUploads),
+		uploadManager:             xfer.NewLayerUploadManager(config.MaxConcurrentUploads, config.MaxUploadAttempts),
 	}
 }
 

--- a/daemon/reload.go
+++ b/daemon/reload.go
@@ -44,6 +44,7 @@ func (daemon *Daemon) Reload(conf *config.Config) (err error) {
 	}
 	daemon.reloadDebug(conf, attributes)
 	daemon.reloadMaxConcurrentDownloadsAndUploads(conf, attributes)
+	daemon.reloadMaxDownloadUploadAttempts(conf, attributes)
 	daemon.reloadShutdownTimeout(conf, attributes)
 	daemon.reloadFeatures(conf, attributes)
 
@@ -107,6 +108,36 @@ func (daemon *Daemon) reloadMaxConcurrentDownloadsAndUploads(conf *config.Config
 	attributes["max-concurrent-downloads"] = fmt.Sprintf("%d", *daemon.configStore.MaxConcurrentDownloads)
 	// prepare reload event attributes with updatable configurations
 	attributes["max-concurrent-uploads"] = fmt.Sprintf("%d", *daemon.configStore.MaxConcurrentUploads)
+}
+
+// reloadMaxDownloadUploadAttempts updates configuration with max
+// download and upload attempts options and updates the passed attributes
+func (daemon *Daemon) reloadMaxDownloadUploadAttempts(conf *config.Config, attributes map[string]string) {
+	// If no value is set for max-download-attempts we assume it is the default value
+	// We always "reset" as the cost is lightweight and easy to maintain.
+	if conf.IsValueSet("max-download-attempts") && conf.MaxDownloadAttempts != nil {
+		*daemon.configStore.MaxDownloadAttempts = *conf.MaxDownloadAttempts
+	} else {
+		maxDownloadAttempts := config.DefaultMaxDownloadAttempts
+		daemon.configStore.MaxDownloadAttempts = &maxDownloadAttempts
+	}
+	logrus.Debugf("Reset Max Download Attempts: %d", *daemon.configStore.MaxDownloadAttempts)
+
+	// If no value is set for max-upload-attempts we assume it is the default value
+	// We always "reset" as the cost is lightweight and easy to maintain.
+	if conf.IsValueSet("max-upload-attempts") && conf.MaxUploadAttempts != nil {
+		*daemon.configStore.MaxUploadAttempts = *conf.MaxUploadAttempts
+	} else {
+		maxUploadAttempts := config.DefaultMaxUploadAttempts
+		daemon.configStore.MaxUploadAttempts = &maxUploadAttempts
+	}
+	logrus.Debugf("Reset Max Upload Attempts: %d", *daemon.configStore.MaxUploadAttempts)
+
+	daemon.imageService.UpdateConfig(conf.MaxDownloadAttempts, conf.MaxUploadAttempts)
+	// prepare reload event attributes with updatable configurations
+	attributes["max-download-attempts"] = fmt.Sprintf("%d", *daemon.configStore.MaxDownloadAttempts)
+	// prepare reload event attributes with updatable configurations
+	attributes["max-upload-attempts"] = fmt.Sprintf("%d", *daemon.configStore.MaxUploadAttempts)
 }
 
 // reloadShutdownTimeout updates configuration with daemon shutdown timeout option

--- a/distribution/xfer/download.go
+++ b/distribution/xfer/download.go
@@ -20,8 +20,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const maxDownloadAttempts = 5
-
 // LayerDownloadManager figures out which layers need to be downloaded, then
 // registers and downloads those, taking into account dependencies between
 // layers.
@@ -29,6 +27,7 @@ type LayerDownloadManager struct {
 	layerStores  map[string]layer.Store
 	tm           TransferManager
 	waitDuration time.Duration
+	retryLimit   int
 }
 
 // SetConcurrency sets the max concurrent downloads for each pull
@@ -37,11 +36,12 @@ func (ldm *LayerDownloadManager) SetConcurrency(concurrency int) {
 }
 
 // NewLayerDownloadManager returns a new LayerDownloadManager.
-func NewLayerDownloadManager(layerStores map[string]layer.Store, concurrencyLimit int, options ...func(*LayerDownloadManager)) *LayerDownloadManager {
+func NewLayerDownloadManager(layerStores map[string]layer.Store, concurrencyLimit, retryLimit int, options ...func(*LayerDownloadManager)) *LayerDownloadManager {
 	manager := LayerDownloadManager{
 		layerStores:  layerStores,
 		tm:           NewTransferManager(concurrencyLimit),
 		waitDuration: time.Second,
+		retryLimit:   retryLimit,
 	}
 	for _, option := range options {
 		option(&manager)
@@ -291,7 +291,7 @@ func (ldm *LayerDownloadManager) makeDownloadFunc(descriptor DownloadDescriptor,
 				}
 
 				retries++
-				if _, isDNR := err.(DoNotRetry); isDNR || retries == maxDownloadAttempts {
+				if _, isDNR := err.(DoNotRetry); isDNR || retries >= ldm.retryLimit {
 					logrus.Errorf("Download failed: %v", err)
 					d.err = err
 					return

--- a/distribution/xfer/download_test.go
+++ b/distribution/xfer/download_test.go
@@ -20,7 +20,10 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
-const maxDownloadConcurrency = 3
+const (
+	maxDownloadConcurrency = 3
+	maxDownloadAttempts    = 5
+)
 
 type mockLayer struct {
 	layerData bytes.Buffer
@@ -285,7 +288,7 @@ func TestSuccessfulDownload(t *testing.T) {
 	layerStore := &mockLayerStore{make(map[layer.ChainID]*mockLayer)}
 	lsMap := make(map[string]layer.Store)
 	lsMap[runtime.GOOS] = layerStore
-	ldm := NewLayerDownloadManager(lsMap, maxDownloadConcurrency, func(m *LayerDownloadManager) { m.waitDuration = time.Millisecond })
+	ldm := NewLayerDownloadManager(lsMap, maxDownloadConcurrency, maxDownloadAttempts, func(m *LayerDownloadManager) { m.waitDuration = time.Millisecond })
 
 	progressChan := make(chan progress.Progress)
 	progressDone := make(chan struct{})
@@ -349,7 +352,7 @@ func TestCancelledDownload(t *testing.T) {
 	layerStore := &mockLayerStore{make(map[layer.ChainID]*mockLayer)}
 	lsMap := make(map[string]layer.Store)
 	lsMap[runtime.GOOS] = layerStore
-	ldm := NewLayerDownloadManager(lsMap, maxDownloadConcurrency, func(m *LayerDownloadManager) { m.waitDuration = time.Millisecond })
+	ldm := NewLayerDownloadManager(lsMap, maxDownloadConcurrency, maxDownloadAttempts, func(m *LayerDownloadManager) { m.waitDuration = time.Millisecond })
 	progressChan := make(chan progress.Progress)
 	progressDone := make(chan struct{})
 

--- a/distribution/xfer/upload.go
+++ b/distribution/xfer/upload.go
@@ -11,13 +11,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const maxUploadAttempts = 5
-
 // LayerUploadManager provides task management and progress reporting for
 // uploads.
 type LayerUploadManager struct {
 	tm           TransferManager
 	waitDuration time.Duration
+	retryLimit   int
 }
 
 // SetConcurrency sets the max concurrent uploads for each push
@@ -26,10 +25,11 @@ func (lum *LayerUploadManager) SetConcurrency(concurrency int) {
 }
 
 // NewLayerUploadManager returns a new LayerUploadManager.
-func NewLayerUploadManager(concurrencyLimit int, options ...func(*LayerUploadManager)) *LayerUploadManager {
+func NewLayerUploadManager(concurrencyLimit, retryLimit int, options ...func(*LayerUploadManager)) *LayerUploadManager {
 	manager := LayerUploadManager{
 		tm:           NewTransferManager(concurrencyLimit),
 		waitDuration: time.Second,
+		retryLimit:   retryLimit,
 	}
 	for _, option := range options {
 		option(&manager)
@@ -140,7 +140,7 @@ func (lum *LayerUploadManager) makeUploadFunc(descriptor UploadDescriptor) DoFun
 				}
 
 				retries++
-				if _, isDNR := err.(DoNotRetry); isDNR || retries == maxUploadAttempts {
+				if _, isDNR := err.(DoNotRetry); isDNR || retries >= lum.retryLimit {
 					logrus.Errorf("Upload failed: %v", err)
 					u.err = err
 					return

--- a/distribution/xfer/upload_test.go
+++ b/distribution/xfer/upload_test.go
@@ -12,7 +12,10 @@ import (
 	"github.com/docker/docker/pkg/progress"
 )
 
-const maxUploadConcurrency = 3
+const (
+	maxUploadConcurrency = 3
+	maxUploadAttempts    = 5
+)
 
 type mockUploadDescriptor struct {
 	currentUploads  *int32
@@ -79,7 +82,7 @@ func uploadDescriptors(currentUploads *int32) []UploadDescriptor {
 }
 
 func TestSuccessfulUpload(t *testing.T) {
-	lum := NewLayerUploadManager(maxUploadConcurrency, func(m *LayerUploadManager) { m.waitDuration = time.Millisecond })
+	lum := NewLayerUploadManager(maxUploadConcurrency, maxUploadAttempts, func(m *LayerUploadManager) { m.waitDuration = time.Millisecond })
 
 	progressChan := make(chan progress.Progress)
 	progressDone := make(chan struct{})
@@ -105,7 +108,7 @@ func TestSuccessfulUpload(t *testing.T) {
 }
 
 func TestCancelledUpload(t *testing.T) {
-	lum := NewLayerUploadManager(maxUploadConcurrency, func(m *LayerUploadManager) { m.waitDuration = time.Millisecond })
+	lum := NewLayerUploadManager(maxUploadConcurrency, maxUploadAttempts, func(m *LayerUploadManager) { m.waitDuration = time.Millisecond })
 
 	progressChan := make(chan progress.Progress)
 	progressDone := make(chan struct{})

--- a/plugin/backend_linux.go
+++ b/plugin/backend_linux.go
@@ -463,7 +463,7 @@ func (pm *Manager) Push(ctx context.Context, name string, metaHeader http.Header
 		pluginID: p.Config,
 	}
 
-	uploadManager := xfer.NewLayerUploadManager(3)
+	uploadManager := xfer.NewLayerUploadManager(3, 5)
 
 	imagePushConfig := &distribution.ImagePushConfig{
 		Config: distribution.Config{


### PR DESCRIPTION
The defaults remain the same (dl=5, ul=5), but are moved from distribution/xfer to
daemon/config.

Connects-to: https://github.com/balena-os/balena-engine/issues/160
Change-type: patch
Signed-off-by: Robert Günzler <robertg@balena.io>