### PR TITLE
integration-tests: Don't fail TestImagePullComparePullDuration

### DIFF
--- a/integration/image/pull_test.go
+++ b/integration/image/pull_test.go
@@ -21,9 +21,8 @@ func TestImagePullComparePullDuration(t *testing.T) {
 			skip.If(t, storageDriver == "aufs", "Aufs doesn't work with dind")
 
 			var (
-				durSync, durNoSync time.Duration
-				args               = []string{fmt.Sprintf("--storage-driver=%s", storageDriver)}
-				testImage          = "balenalib/amd64-debian:build" // should have a few layers so it actually has an impact on pull performance
+				args      = []string{fmt.Sprintf("--storage-driver=%s", storageDriver)}
+				testImage = "balenalib/amd64-debian:build" // should have a few layers so it actually has an impact on pull performance
 			)
 
 			d := daemon.New(t)
@@ -37,8 +36,7 @@ func TestImagePullComparePullDuration(t *testing.T) {
 			ctx := context.Background()
 			start := time.Now()
 			_, err = client.ImagePull(ctx, testImage, types.ImagePullOptions{})
-			durSync = time.Now().Sub(start)
-			t.Logf("%s/syncDiffs=true took %s", t.Name(), durSync)
+			t.Logf("%s/syncDiffs=true took %s", t.Name(), time.Now().Sub(start))
 			assert.NilError(t, err)
 
 			d.Stop(t)
@@ -47,11 +45,8 @@ func TestImagePullComparePullDuration(t *testing.T) {
 
 			start = time.Now()
 			_, err = client.ImagePull(ctx, testImage, types.ImagePullOptions{})
-			durNoSync = time.Now().Sub(start)
-			t.Logf("%s/syncDiffs=false took %s", t.Name(), durNoSync)
+			t.Logf("%s/syncDiffs=false took %s", t.Name(), time.Now().Sub(start))
 			assert.NilError(t, err)
-
-			assert.Assert(t, durSync > durNoSync)
 		})
 	}
 }


### PR DESCRIPTION
The recoded times are very flaky when running on travis, however locally they
seem solid.
One can still inspect the behavior by looking at the output of the test
case, but we shouldn't fail the entire integration test suite on this.

Signed-off-by: Robert Günzler <robertg@balena.io>