### PR TITLE
[17.12 backport] Add containerd-ctr healthcheck command

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -103,7 +103,7 @@ github.com/googleapis/gax-go da06d194a00e19ce00d9011a13931c3f6f6887c7
 google.golang.org/genproto d80a6e20e776b0b17a324d0ba1ab50a39c8e8944
 
 # containerd
-github.com/containerd/containerd cfb2762429666d7f1d1bf9a3d2da7d8d1dd18c52 https://github.com/balena-os/balena-containerd # seed random backport
+github.com/containerd/containerd 94dd86f895956b422cd26b515e7af5d6c984e636 https://github.com/balena-os/balena-containerd # ctr health command
 github.com/containerd/btrfs 2e1aa0ddf94f91fa282b6ed87c23bf0d64911244
 github.com/containerd/fifo fbfb6a11ec671efbe94ad1c12c2e98773f19e1e6
 github.com/containerd/continuity 35d55c5e8dd23b32037d56cf97174aff3efdfa83

--- a/vendor/github.com/containerd/containerd/cmd/ctr/commands/health/health.go
+++ b/vendor/github.com/containerd/containerd/cmd/ctr/commands/health/health.go
@@ -1,0 +1,49 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package health
+
+import (
+	"github.com/containerd/containerd/cmd/ctr/commands"
+	"github.com/urfave/cli"
+	health "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// Command runs a container
+var Command = cli.Command{
+	Name:  "health",
+	Usage: "checks containerd health",
+	Action: func(context *cli.Context) error {
+		client, ctx, cancel, err := commands.NewClient(context)
+		if err != nil {
+			return err
+		}
+		defer cancel()
+
+		hs := client.HealthService()
+		response, err := hs.Check(ctx, &health.HealthCheckRequest{})
+		if err != nil {
+			return err
+		}
+
+		status := response.Status
+		if status != health.HealthCheckResponse_SERVING {
+			return cli.NewExitError(status.String(), 1)
+		}
+
+		return cli.NewExitError(status.String(), 0)
+	},
+}

--- a/vendor/github.com/containerd/containerd/cmd/ctr/main.go
+++ b/vendor/github.com/containerd/containerd/cmd/ctr/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/containerd/containerd/cmd/ctr/commands/containers"
 	"github.com/containerd/containerd/cmd/ctr/commands/content"
 	"github.com/containerd/containerd/cmd/ctr/commands/events"
+	"github.com/containerd/containerd/cmd/ctr/commands/health"
 	"github.com/containerd/containerd/cmd/ctr/commands/images"
 	namespacesCmd "github.com/containerd/containerd/cmd/ctr/commands/namespaces"
 	"github.com/containerd/containerd/cmd/ctr/commands/plugins"
@@ -83,6 +84,7 @@ containerd CLI
 		containers.Command,
 		content.Command,
 		events.Command,
+		health.Command,
 		images.Command,
 		namespacesCmd.Command,
 		pprof.Command,


### PR DESCRIPTION
Connects-to: https://github.com/balena-os/balena-containerd/pull/3
Connects-to: https://github.com/balena-os/meta-balena/issues/1391
Connects-to: https://github.com/balena-os/balena-engine/issues/142
Change-type: patch
Signed-off-by: Robert Günzler <robertg@balena.io>