### PR TITLE
[17.12] dockerfile-build: move to balenalib

### DIFF
--- a/Dockerfile.build.aarch64
+++ b/Dockerfile.build.aarch64
@@ -1,4 +1,4 @@
-FROM resin/aarch64-golang:1.10
+FROM balenalib/raspberrypi3-64-golang:1.10
 
 # Enable QEMU emulation
 ENTRYPOINT [ "qemu-aarch64-static", "-execve" ]
@@ -11,7 +11,6 @@ RUN apt-get update \
 		libdevmapper-dev \
 		libnl-3-dev \
 		libsystemd-dev \
-		libsystemd-journal-dev \
 		libudev-dev
 
 COPY . /balena-engine

--- a/Dockerfile.build.arm
+++ b/Dockerfile.build.arm
@@ -1,4 +1,4 @@
-FROM resin/raspberrypi3-golang:1.10
+FROM balenalib/raspberrypi3-golang:1.10
 
 # Enable QEMU emulation
 ENTRYPOINT [ "qemu-arm-static", "-execve" ]
@@ -11,7 +11,6 @@ RUN apt-get update \
 		libdevmapper-dev \
 		libnl-3-dev \
 		libsystemd-dev \
-		libsystemd-journal-dev \
 		libudev-dev
 
 COPY . /balena-engine

--- a/Dockerfile.build.i386
+++ b/Dockerfile.build.i386
@@ -1,4 +1,4 @@
-FROM resin/i386-golang:1.10
+FROM balenalib/i386-golang:1.10
 
 RUN apt-get update \
 	&& apt-get install -y \
@@ -7,7 +7,6 @@ RUN apt-get update \
 		libdevmapper-dev \
 		libnl-3-dev \
 		libsystemd-dev \
-		libsystemd-journal-dev \
 		libudev-dev
 
 COPY . /balena-engine

--- a/Dockerfile.build.x86_64
+++ b/Dockerfile.build.x86_64
@@ -1,4 +1,4 @@
-FROM resin/amd64-golang:1.10
+FROM balenalib/amd64-golang:1.10
 
 RUN apt-get update \
 	&& apt-get install -y \
@@ -7,7 +7,6 @@ RUN apt-get update \
 		libdevmapper-dev \
 		libnl-3-dev \
 		libsystemd-dev \
-		libsystemd-journal-dev \
 		libudev-dev
 
 COPY . /balena-engine


### PR DESCRIPTION
and remove outdated "libsystemd-journal-dev" package

This should fix the recent build failures on the 17.12-resin branch