### PR TITLE
Allow passing container ID to container via environment variable

### DIFF
--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -358,6 +358,7 @@ type HostConfig struct {
 	// Applicable to all platforms
 	Binds           []string      // List of volume bindings for this container
 	ContainerIDFile string        // File (path) where the containerId is written
+	ContainerIDEnv  string        // Environment variable name to use for passing containerId
 	LogConfig       LogConfig     // Configuration of the logs for this container
 	NetworkMode     NetworkMode   // Network mode to use for the container
 	PortBindings    nat.PortMap   // Port mapping between the exposed port (container) and the host

--- a/integration/container/cid_env_test.go
+++ b/integration/container/cid_env_test.go
@@ -1,0 +1,61 @@
+package container // import "github.com/docker/docker/integration/container"
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	testcontainer "github.com/docker/docker/integration/internal/container"
+
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+)
+
+func TestContainerIDEnvOK(t *testing.T) {
+	defer setupTest(t)()
+
+	var cidEnv = "CONTAINER_ID"
+	ctx := context.Background()
+	apiclient := testEnv.APIClient()
+
+	config := &testcontainer.TestContainerConfig{
+		Config: &container.Config{
+			Image: "busybox",
+			Cmd:   []string{"top"},
+		},
+		HostConfig: &container.HostConfig{
+			ContainerIDEnv: cidEnv,
+		},
+		NetworkingConfig: &network.NetworkingConfig{},
+	}
+	resp, err := apiclient.ContainerCreate(ctx, config.Config, config.HostConfig, config.NetworkingConfig, config.Name)
+	assert.NilError(t, err)
+
+	c, err := apiclient.ContainerInspect(ctx, resp.ID)
+	assert.NilError(t, err)
+	expected := fmt.Sprintf("%s=%s", cidEnv, resp.ID)
+	assert.Check(t, is.Contains(c.Config.Env, expected))
+}
+
+func TestContainerIDEnvVariableExists(t *testing.T) {
+	defer setupTest(t)()
+
+	var cidEnv = "PATH"
+	ctx := context.Background()
+	apiclient := testEnv.APIClient()
+
+	config := &testcontainer.TestContainerConfig{
+		Config: &container.Config{
+			Image: "busybox",
+			Cmd:   []string{"top"},
+		},
+		HostConfig: &container.HostConfig{
+			ContainerIDEnv: cidEnv,
+		},
+		NetworkingConfig: &network.NetworkingConfig{},
+	}
+	_, err := apiclient.ContainerCreate(ctx, config.Config, config.HostConfig, config.NetworkingConfig, config.Name)
+	assert.ErrorContains(t, err, fmt.Sprintf("environment variable %s already defined", cidEnv))
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -168,7 +168,7 @@ github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75 # 
 github.com/Nvveen/Gotty a8b993ba6abdb0e0c12b0125c603323a71c7790c https://github.com/ijc25/Gotty
 
 # docker CLI
-github.com/docker/cli ea7a18b0e998c2a07bc8ef3f8d6982243209bd60 https://github.com/balena-os/balena-engine-cli
+github.com/docker/cli f2d17136411d9987af2af06b88f2bbc87114d01e https://github.com/balena-os/balena-engine-cli
 github.com/mitchellh/mapstructure f3009df150dadf309fdee4a54ed65c124afad715
 gopkg.in/yaml.v2 4c78c975fe7c825c6d1466c42be594d1d6f3aba6
 github.com/docker/docker-credential-helpers 3c90bd29a46b943b2a9842987b58fb91a7c1819b

--- a/vendor/github.com/docker/cli/cli/command/container/opts.go
+++ b/vendor/github.com/docker/cli/cli/command/container/opts.go
@@ -72,6 +72,7 @@ type containerOptions struct {
 	oomKillDisable     bool
 	oomScoreAdj        int
 	containerIDFile    string
+	containerIDEnv     string
 	entrypoint         string
 	hostname           string
 	memory             opts.MemBytes
@@ -240,6 +241,7 @@ func addFlags(flags *pflag.FlagSet) *containerOptions {
 	flags.Uint16Var(&copts.blkioWeight, "blkio-weight", 0, "Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)")
 	flags.Var(&copts.blkioWeightDevice, "blkio-weight-device", "Block IO weight (relative device weight)")
 	flags.StringVar(&copts.containerIDFile, "cidfile", "", "Write the container ID to the file")
+	flags.StringVar(&copts.containerIDEnv, "cidenv", "", "Write the container ID to the environment variable")
 	flags.StringVar(&copts.cpusetCpus, "cpuset-cpus", "", "CPUs in which to allow execution (0-3, 0,1)")
 	flags.StringVar(&copts.cpusetMems, "cpuset-mems", "", "MEMs in which to allow execution (0-3, 0,1)")
 	flags.Int64Var(&copts.cpuCount, "cpu-count", 0, "CPU count (Windows only)")
@@ -577,6 +579,7 @@ func parse(flags *pflag.FlagSet, copts *containerOptions) (*containerConfig, err
 	hostConfig := &container.HostConfig{
 		Binds:           binds,
 		ContainerIDFile: copts.containerIDFile,
+		ContainerIDEnv:  copts.containerIDEnv,
 		OomScoreAdj:     copts.oomScoreAdj,
 		AutoRemove:      copts.autoRemove,
 		Privileged:      copts.privileged,


### PR DESCRIPTION
This adds a new ContainerIDEnv field to HostConfig that can pass an
environment variable name, which will be set to the container ID and
passed to the container environment.

Change-type: patch
Connects-to: https://github.com/balena-os/balena-engine/issues/173
Signed-off-by: Robert Günzler <robertg@balena.io>