### PR TITLE
Fix CLI versioning

### DIFF
--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!exclude_graphdriver_btrfs
 
 package btrfs // import "github.com/docker/docker/daemon/graphdriver/btrfs"
 

--- a/daemon/graphdriver/btrfs/btrfs_test.go
+++ b/daemon/graphdriver/btrfs/btrfs_test.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!exclude_graphdriver_btrfs
 
 package btrfs // import "github.com/docker/docker/daemon/graphdriver/btrfs"
 

--- a/daemon/graphdriver/btrfs/dummy_unsupported.go
+++ b/daemon/graphdriver/btrfs/dummy_unsupported.go
@@ -1,3 +1,3 @@
-// +build !linux !cgo
+// +build !linux !cgo exclude_graphdriver_btrfs
 
 package btrfs // import "github.com/docker/docker/daemon/graphdriver/btrfs"

--- a/daemon/graphdriver/btrfs/version.go
+++ b/daemon/graphdriver/btrfs/version.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!exclude_graphdriver_btrfs
 
 package btrfs // import "github.com/docker/docker/daemon/graphdriver/btrfs"
 

--- a/daemon/graphdriver/btrfs/version_test.go
+++ b/daemon/graphdriver/btrfs/version_test.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,!exclude_graphdriver_btrfs
 
 package btrfs // import "github.com/docker/docker/daemon/graphdriver/btrfs"
 

--- a/hack/dockerfile/install/gotestsum.installer
+++ b/hack/dockerfile/install/gotestsum.installer
@@ -2,10 +2,10 @@
 
 GOTESTSUM_COMMIT='v0.3.5'
 
-install_gotestsum() {
-	echo "Installing gotestsum version $GOTESTSUM_COMMIT"
-	go get -d gotest.tools/gotestsum
-	cd "$GOPATH/src/gotest.tools/gotestsum"
-	git checkout -q "$GOTESTSUM_COMMIT"
+install_gotestsum() (
+	set -e
+	export GO111MODULE=on
+	go get -d "gotest.tools/gotestsum@${GOTESTSUM_COMMIT}"
 	go build -buildmode=pie -o "${PREFIX}/gotestsum" 'gotest.tools/gotestsum'
-}
+
+)

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -68,9 +68,9 @@ else
 	exit 1
 fi
 LDFLAGS="\
-    -X \"github.com/docker/docker/vendor/github.com/docker/cli/cli.GitCommit=${GITCOMMIT}\" \
-    -X \"github.com/docker/docker/vendor/github.com/docker/cli/cli.BuildTime=${BUILDTIME}\" \
-    -X \"github.com/docker/docker/vendor/github.com/docker/cli/cli.Version=${VERSION}\" \
+    -X \"github.com/docker/docker/vendor/github.com/docker/cli/cli/version.GitCommit=${GITCOMMIT}\" \
+    -X \"github.com/docker/docker/vendor/github.com/docker/cli/cli/version.BuildTime=${BUILDTIME}\" \
+    -X \"github.com/docker/docker/vendor/github.com/docker/cli/cli/version.Version=${VERSION}\" \
 "
 
 if [ "$AUTO_GOPATH" ]; then

--- a/profiles/seccomp/seccomp.go
+++ b/profiles/seccomp/seccomp.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,seccomp
 
 package seccomp // import "github.com/docker/docker/profiles/seccomp"
 

--- a/profiles/seccomp/seccomp_test.go
+++ b/profiles/seccomp/seccomp_test.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,seccomp
 
 package seccomp // import "github.com/docker/docker/profiles/seccomp"
 


### PR DESCRIPTION
balena-os/balena-engine-cli@20c1983
moves the versioning variables to a separate package. We have to adjust
the location in hack/make.sh too

also backports a fix from upstream to fix the gotestsum installer