### PR TITLE
Lock destination layers while delta is being processed

### DIFF
--- a/integration/image/delta_test.go
+++ b/integration/image/delta_test.go
@@ -1,17 +1,19 @@
 package image
 
 import (
+	"bufio"
 	"context"
 	"io"
 	"io/ioutil"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/api/types"
 	apiclient "github.com/docker/docker/client"
 )
 
-// TestDelta just creates a delta and checks if it exists
-func TestDelta(t *testing.T) {
+// TestDeltaCreate creates a delta and checks if it exists
+func TestDeltaCreate(t *testing.T) {
 	var (
 		base   = "busybox:1.24"
 		target = "busybox:1.29"
@@ -39,6 +41,75 @@ func TestDelta(t *testing.T) {
 	io.Copy(ioutil.Discard, rc)
 	rc.Close()
 
+	_, _, err = client.ImageInspectWithRaw(ctx, delta)
+	if err != nil {
+		t.Fatalf("Inspecting delta: %s", err)
+	}
+}
+
+// TestDeltaCreateDestinationLock triggers a delta generation job, waits for it
+// to start and removes the destination image.
+//
+// Until 1e83de47e32ac0caf3b4e02094aeb76da28b90b3 this would remove unprocessed
+// destination layers and break delta generation.
+func TestDeltaCreateDestinationLock(t *testing.T) {
+	var (
+		base   = "debian:8"
+		target = "debian:10"
+		delta  = "debian:delta"
+	)
+
+	var (
+		err    error
+		rc     io.ReadCloser
+		ctx    = context.Background()
+		client = testEnv.APIClient()
+	)
+
+	pullBaseAndTargetImages(t, client, base, target)
+
+	rc, err = client.ImageDelta(ctx,
+		base,
+		target,
+		types.ImageDeltaOptions{
+			Tag: delta,
+		})
+	if err != nil {
+		t.Fatalf("Creating delta: %s", err)
+	}
+	defer rc.Close()
+
+	var (
+		waitFingerprinting = make(chan struct{})
+		waitDelta          = make(chan struct{})
+	)
+	go func() {
+		defer close(waitFingerprinting)
+		defer close(waitDelta)
+		for br := bufio.NewReader(rc); ; {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				t.Fatal(err)
+			}
+			if strings.Contains(line, "Fingerprint complete") {
+				waitFingerprinting <- struct{}{}
+			}
+			if strings.Contains(line, "layer does not exist") {
+				t.Fail()
+			}
+		}
+	}()
+
+	<-waitFingerprinting
+	_, err = client.ImageRemove(ctx, target, types.ImageRemoveOptions{})
+	if err != nil {
+		t.Fatalf("Removing target image failed: %s", err)
+	}
+
+	<-waitDelta
 	_, _, err = client.ImageInspectWithRaw(ctx, delta)
 	if err != nil {
 		t.Fatalf("Inspecting delta: %s", err)


### PR DESCRIPTION
During fingerpinting of the source image the destination layers are not
exepmt from being released (e.g. when `balena image rm <iid>`) is run
simultaneously.
Similarly when processing the destination layers to generate deltas we
only hold one reference at a time, leaving the subsequent layers
vulnerable to the same issues.

Change-type: patch
Signed-off-by: Robert Günzler <robertg@balena.io>