### PR TITLE
top_unix.go: allow busybox ps with no args

### DIFF
--- a/daemon/top_unix.go
+++ b/daemon/top_unix.go
@@ -170,14 +170,18 @@ func (daemon *Daemon) ContainerTop(name string, psArgs string) (*container.Conta
 		// so retry without it
 		output, err = exec.Command("ps", args...).Output()
 		if err != nil {
-			if ee, ok := err.(*exec.ExitError); ok {
-				// first line of stderr shows why ps failed
-				line := bytes.SplitN(ee.Stderr, []byte{'\n'}, 2)
-				if len(line) > 0 && len(line[0]) > 0 {
-					err = errors.New(string(line[0]))
+			// busybox ps compiled in non-desktop mode supports no args
+			output, err = exec.Command("ps").Output()
+			if err != nil {
+				if ee, ok := err.(*exec.ExitError); ok {
+					// first line of stderr shows why ps failed
+					line := bytes.SplitN(ee.Stderr, []byte{'\n'}, 2)
+					if len(line) > 0 && len(line[0]) > 0 {
+						err = errors.New(string(line[0]))
+					}
 				}
-			}
-			return nil, errdefs.System(errors.Wrap(err, "ps"))
+				return nil, errdefs.System(errors.Wrap(err, "ps"))
+		}
 		}
 	}
 	procList, err := parsePSOutput(output, procs)


### PR DESCRIPTION
Busybox in balenaOS is compiled with desktop mode disabled,
so features like `-ef` and providing pids via `-q` are not
supported. Add a 3rd condition to try ps with no args and allow
parsePSOutput to filter by pid.

https://github.com/balena-os/balena-engine/issues/236

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>

**- What I did**
Adjusted `balena top` to not pass any args to `ps` for cases where a minimal busybox, not procps, is used.

**- How I did it**
There were already two conditions to try passing different args into ps, including one that didn't provide `-qpid1,pid2` so we are already relying on the pid filter in `parsePSOutput`. I added a 3rd fallback to also avoid passing `-ef`.

**- How to verify it**
I built a custom balenaOS image for raspberrypi4-64 and confirmed that `balena top <container-id>` does not return the error described in #236 when using this patched balena-engine.

Note that many busybox builds do support the `-ef` flags unless they were compiled without `CONFIG_DESKTOP=y` as is the case with balenaOS.

**- Description for the changelog**
Fix "balena top" command for distros using a non-desktop busybox and not procps.
