### PR TITLE
pkg/storagemigration: poperly handle errors during state creation

### DIFF
--- a/pkg/storagemigration/migrate.go
+++ b/pkg/storagemigration/migrate.go
@@ -50,6 +50,9 @@ func Migrate(root string) (err error) {
 	// We need to pay special attention to the whiteout metadata files used by aufs to
 	// mark deleted files and empty directories.
 	state, err := createState(aufsRoot(root))
+	if err != nil {
+		return err
+	}
 
 	logrus.Infof("transforming %d layers(s) to overlay2", len(state.Layers))
 


### PR DESCRIPTION
verify with `make TESTDIRS=./pkg/storagemigration test-unit`, prior to b8170db554ac1d1abb3adcfe1f6265701e9147c5 should panic like this:

```
=== FAIL: pkg/storagemigration TestMigrateFailure (0.01s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x92f3c8]

goroutine 12 [running]:
testing.tRunner.func1(0xc0000ceb00)
	/usr/local/go/src/testing/testing.go:830 +0x392
panic(0x9be440, 0x1109f70)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
github.com/docker/docker/pkg/storagemigration.Migrate(0xc00009d320, 0x21, 0xb175a0, 0xc000065c40)
	/go/src/github.com/docker/docker/pkg/storagemigration/migrate.go:54 +0x2a8
github.com/docker/docker/pkg/storagemigration.TestMigrateFailure(0xc0000ceb00)
	/go/src/github.com/docker/docker/pkg/storagemigration/migrate_test.go:76 +0x310
testing.tRunner(0xc0000ceb00, 0xa7a148)
	/usr/local/go/src/testing/testing.go:865 +0xc0
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:916 +0x35a
FAIL	github.com/docker/docker/pkg/storagemigration	0.006s
```

Change-type: patch
Signed-off-by: Robert Günzler <robertg@balena.io>
