### PR TITLE
Make layer download resuming more resilient

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -561,15 +561,14 @@ func (p *v2Puller) pullSchema2Layers(ctx context.Context, target distribution.De
 	defer cancel()
 
 	var (
-		downloadedRootFS *image.RootFS  // rootFS from registered layers
-		release          func()         // release resources from rootFS download
+		downloadedRootFS *image.RootFS // rootFS from registered layers
+		release          func()        // release resources from rootFS download
 	)
 
 	layerStoreOS := runtime.GOOS
 	if platform != nil {
 		layerStoreOS = platform.OS
 	}
-
 
 	if len(descriptors) != len(configRootFS.DiffIDs) {
 		return "", errRootFSMismatch

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -198,6 +198,12 @@ func (ld *v2LayerDescriptor) Read(p []byte) (int, error) {
 		sleepDurationInSecs := int(math.Pow(2, float64(ld.downloadRetries-1)))
 		logrus.Infof("waiting %vs before retrying layer download", sleepDurationInSecs)
 		for sleepDurationInSecs > 0 {
+			if ld.ctx.Err() == context.Canceled {
+				// Stop the pull immediately on context cancellation (caused
+				// e.g. by Ctrl+C).
+				logrus.Info("context canceled during wait, interrupting layer download")
+				return 0, context.Canceled
+			}
 			plural := (map[bool]string{true: "s"})[sleepDurationInSecs != 1]
 			progress.Updatef(ld.progressOutput, ld.ID(), "Retrying in %v second%v", sleepDurationInSecs, plural)
 			time.Sleep(time.Second)
@@ -229,6 +235,10 @@ func (ld *v2LayerDescriptor) Read(p []byte) (int, error) {
 		if !ld.verifier.Verified() {
 			return n, fmt.Errorf("filesystem layer verification failed for digest %s", ld.digest)
 		}
+	case context.Canceled:
+		// Context cancelation is triggered e.g. when the user hits Ctrl+C on
+		// the CLI. We want to stop the pull in this case.
+		logrus.Info("context canceled, interrupting layer download")
 	default:
 		logrus.Warnf("failed to download layer: \"%v\", retrying to read again", err)
 		ld.downloadRetries += 1

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/url"
 	"os"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/docker/distribution"
@@ -41,7 +43,7 @@ var (
 	errRootFSInvalid  = errors.New("invalid rootfs in image configuration")
 )
 
-const maxDownloadAttempts = 5
+const maxDownloadAttempts = 10
 
 // ImageConfigPullError is an error pulling the image config blob
 // (only applies to schema2).
@@ -145,9 +147,10 @@ type v2LayerDescriptor struct {
 	src               distribution.Descriptor
 	ctx               context.Context
 	layerDownload     io.ReadCloser
-	downloadAttempts  uint8
+	downloadRetries   uint8 // Number of retries since last successful download attempt
 	downloadOffset    int64
 	deltaBase         io.ReadSeeker
+	progressOutput    progress.Output
 }
 
 func (ld *v2LayerDescriptor) Key() string {
@@ -186,26 +189,49 @@ func (ld *v2LayerDescriptor) reset() error {
 }
 
 func (ld *v2LayerDescriptor) Read(p []byte) (int, error) {
-	if ld.downloadAttempts <= 0 {
+	if ld.downloadRetries > maxDownloadAttempts {
+		logrus.Warnf("giving up layer download after %v retries", maxDownloadAttempts)
 		return 0, fmt.Errorf("no request retries left")
+	}
+
+	if ld.downloadRetries > 0 {
+		sleepDurationInSecs := int(math.Pow(2, float64(ld.downloadRetries-1)))
+		logrus.Infof("waiting %vs before retrying layer download", sleepDurationInSecs)
+		for sleepDurationInSecs > 0 {
+			plural := (map[bool]string{true: "s"})[sleepDurationInSecs != 1]
+			progress.Updatef(ld.progressOutput, ld.ID(), "Retrying in %v second%v", sleepDurationInSecs, plural)
+			time.Sleep(time.Second)
+			sleepDurationInSecs--
+		}
 	}
 
 	if ld.layerDownload == nil {
 		if err := ld.reset(); err != nil {
-			ld.downloadAttempts -= 1
-			return 0, err
+			logrus.Infof("failed to reset layer download: %v", err)
+			ld.downloadRetries += 1
+			// Don't report this as an error, as we might still want to retry
+			return 0, nil
 		}
 	}
 
 	n, err := ld.layerDownload.Read(p)
 	ld.downloadOffset += int64(n)
-	if err == io.EOF {
+	switch err {
+	case nil:
+		// We want to give up only after a long period failing to download
+		// anything at all. So, we reset the retries counter after every bit
+		// successfully downloaded.
+		if ld.downloadRetries > 0 {
+			logrus.Infof("download resumed after %v retries", ld.downloadRetries)
+			ld.downloadRetries = 0
+		}
+	case io.EOF:
 		if !ld.verifier.Verified() {
 			return n, fmt.Errorf("filesystem layer verification failed for digest %s", ld.digest)
 		}
-	} else if err != nil {
+	default:
 		logrus.Warnf("failed to download layer: \"%v\", retrying to read again", err)
-		ld.downloadAttempts -= 1
+		ld.downloadRetries += 1
 		ld.layerDownload = nil
 		err = nil
 	}
@@ -228,8 +254,9 @@ func (ld *v2LayerDescriptor) Download(ctx context.Context, progressOutput progre
 
 	ld.ctx = ctx
 	ld.layerDownload = nil
-	ld.downloadAttempts = maxDownloadAttempts
+	ld.downloadRetries = 0
 	ld.verifier = ld.digest.Verifier()
+	ld.progressOutput = progressOutput
 
 	progress.Update(progressOutput, ld.ID(), "Ready to download")
 


### PR DESCRIPTION
This commit changes the way we retry layer downloads after failures with
the goal of making it more resilient, especially for cases involving
large layers and unreliable network connections.

These are the changes:

* Make sure we also retry after failures in `v2LayerDescriptor.reset()`.
  This method creates a new HTTP request to resume a failed download,
  and therefore depends on a working network to succeed.
* Wait exponentially longer times between retries (instead of retrying
  immediately as before). This shall increase of success in case of
  network issues that take longer to get resolved.
* Increase the number of retries to 10.
* Reset retry count whenever we successfully download anything at all.
  The idea is that we want to give up downloading only after a long
  continuous period of failures. Combined with the exponential back-off
  strategy and increased number of retries described above, a layer pull
  will fail only after about 17 minutes.
* Add a bit more logging to help with troubleshooting.

Change-type: minor
Signed-off-by: Leandro Motta Barros <leandro@balena.io>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/balena-os/balena-engine/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For general information on balenaEngine visit https://www.balena.io/engine

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
