### PR TITLE
fix panic in concatReadSeekCloser

### DIFF
--- a/pkg/ioutils/concat.go
+++ b/pkg/ioutils/concat.go
@@ -52,7 +52,7 @@ func (self *concatReadSeekCloser) Read(p []byte) (n int, err error) {
 			return 0, err
 		}
 
-		nA, err := io.ReadFull(self.a, p[:min(len(p), int(self.aSize - self.off))])
+		nA, err := io.ReadFull(self.a, p[:max(0, min(len(p), int(self.aSize - self.off)))])
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
I guess slow reads could lead to 0 sized buffers and thus unexpected behavior