### PR TITLE
Boost daemons' CPU scheduling priority

### DIFF
--- a/cmd/balena-engine/main.go
+++ b/cmd/balena-engine/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/containerd/containerd/cmd/containerd"
 	containerdShim "github.com/containerd/containerd/cmd/containerd-shim"
 	"github.com/containerd/containerd/cmd/ctr"
@@ -26,8 +27,10 @@ func main() {
 	case "balena", "balena-engine":
 		docker.Main()
 	case "balenad", "balena-engine-daemon":
+		setScheduler(SCHED_RR, 35)
 		dockerd.Main()
 	case "balena-containerd", "balena-engine-containerd":
+		setScheduler(SCHED_RR|SCHED_RESET_ON_FORK, 35)
 		containerd.Main()
 	case "balena-containerd-shim", "balena-engine-containerd-shim":
 		containerdShim.Main()
@@ -38,7 +41,7 @@ func main() {
 	case "balena-proxy", "balena-engine-proxy":
 		proxy.Main()
 	default:
-		fmt.Fprintf(os.Stderr, "error: unkown command: %v\n", command)
+		fmt.Fprintf(os.Stderr, "error: unknown command: %v\n", command)
 		os.Exit(1)
 	}
 }

--- a/cmd/balena-engine/sched_linux.go
+++ b/cmd/balena-engine/sched_linux.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"io/ioutil"
+	"math"
+	"strconv"
+	"time"
+	"unsafe"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+// Scheduling policies.
+const (
+	SCHED_NORMAL        = 0
+	SCHED_FIFO          = 1
+	SCHED_RR            = 2
+	SCHED_BATCH         = 3
+	SCHED_RESET_ON_FORK = 0x40000000 // Meant to be ORed with the others
+)
+
+// setScheduler sets the scheduling policy and priority of all threads in the
+// current process.
+func setScheduler(policy, prio int) {
+	// The Go runtime can (and does) create new threads after the program
+	// startup. We therefore keep looping for some minutes in a goroutine,
+	// setting the priorities of any new threads. From experimentation, we see
+	// no new threads created after a handful of minutes, so we don't need an
+	// infinite loop.
+	go func() {
+		type sched_param struct {
+			sched_priority int
+		}
+		s := &sched_param{int(prio)}
+		p := unsafe.Pointer(s)
+		doneTIDs := map[int]bool{}
+
+		for i := 1; i <= 8; i++ {
+			tids, err := getAllTasks()
+			if err != nil {
+				logrus.Errorf("Error getting task list: %v\n", err)
+			}
+			for _, tid := range tids {
+				if _, done := doneTIDs[tid]; done {
+					continue
+				}
+				_, _, errno := unix.Syscall(unix.SYS_SCHED_SETSCHEDULER, uintptr(tid), uintptr(policy), uintptr(p))
+				if errno != 0 {
+					logrus.Errorf("Syscall SYS_SCHED_SETSCHEDULER failed for tid=%v policy=%v prio=%v: %v\n",
+						tid, policy, prio, errno)
+				}
+				doneTIDs[tid] = true
+				logrus.Debugf("Priority of tid=%v set to policy=%v prio=%v", tid, policy, prio)
+			}
+
+			// From experimentation, we see that most threads are created in the
+			// first seconds since program startup, so we increase the sleep
+			// time exponentially to reduce the load we add to the system.
+			sleepTime := time.Duration(math.Pow(2, float64(i))) * time.Second
+			time.Sleep(sleepTime)
+		}
+	}()
+}
+
+// getAllTasks returns a list with the IDs of all tasks (threads) of the
+// currently running process.
+func getAllTasks() ([]int, error) {
+	files, err := ioutil.ReadDir("/proc/self/task/")
+	if err != nil {
+		return nil, err
+	}
+
+	tids := []int{}
+	for _, file := range files {
+		tid, err := strconv.Atoi(file.Name())
+		if err != nil {
+			return tids, err
+		}
+		tids = append(tids, tid)
+	}
+
+	return tids, nil
+}


### PR DESCRIPTION
In order to keep balenaEngine responsive during situations of high system load, this commit increases the scheduling priority of `balenad` and `balena-engine-containerd`.

They are both assigned to real-time scheduling policies, and in the case of `balena-engine-containerd` we make sure to also set the `SCHED_RESET_ON_FORK` flag to make sure that user containers don't inherit the increased priority.

Did manual testing, using this on a Pi Zero that is running a large number of `stress` processes with CPU, memory, I/O and disk loads. Generally increased the time the Engine survives before being killed by the watchdog (but see the caveats list below).

Some possible caveats: 

* While this generally improved the Engine survivability (even allowing it to run for multiple hours in some cases), it's far from perfect. It's not rare to have the watchdog killing the Engine after a couple dozen of minutes, and things like updating the user containers drastically increase the chances of triggering the watchdog.
* This PR deals only with CPU. We need to do something similar for I/O. 

**- What I did**
Change the scheduling policy of balenaEngine daemons to Round Robin (one of the Linux real-time scheduling policies).

**- How I did it**
By calling the `SYS_SCHED_SETSCHEDULER` syscall on each of the daemons' threads.

**- How to verify it**
Manual testing, running this version of the Engine on a Pi Zero with a stress-testing container and comparing with a vanilla Engine.  

**- Description for the changelog**
Boost daemons' CPU scheduling priority
