### PR TITLE
update balena-engine.service

### DIFF
--- a/contrib/init/systemd/balena-engine.service
+++ b/contrib/init/systemd/balena-engine.service
@@ -1,7 +1,7 @@
 [Unit]
-Description=Docker Application Container Engine
-Documentation=https://docs.docker.com
-After=network-online.target docker.socket firewalld.service
+Description=Balena Application Container Engine
+Documentation=https://www.balena.io/engine/docs
+After=network-online.target balena-engine.socket firewalld.service
 Wants=network-online.target
 Requires=balena-engine.socket
 
@@ -9,7 +9,7 @@ Requires=balena-engine.socket
 Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
-# for containers run by docker
+# for containers run by balena-engine
 ExecStart=/usr/bin/balena-engine-daemon -H fd://
 ExecReload=/bin/kill -s HUP $MAINPID
 LimitNOFILE=1048576
@@ -21,11 +21,11 @@ LimitCORE=infinity
 # Only systemd 226 and above support this version.
 #TasksMax=infinity
 TimeoutStartSec=0
-# set delegate yes so that systemd does not reset the cgroups of docker containers
+# set delegate yes so that systemd does not reset the cgroups of balena-engine containers
 Delegate=yes
-# kill only the docker process, not all processes in the cgroup
+# kill only the balena-engine process, not all processes in the cgroup
 KillMode=process
-# restart the docker process if it exits prematurely
+# restart the balena-engine process if it exits prematurely
 Restart=on-failure
 StartLimitBurst=3
 StartLimitInterval=60s


### PR DESCRIPTION
Currently this file is used by [Buildroot](https://git.busybox.net/buildroot/tree/package/balena-engine/balena-engine.mk#n43).