### PR TITLE
Log more info when raising errRootFSMismatch

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -665,6 +665,12 @@ func (p *v2Puller) pullSchema2Layers(ctx context.Context, target distribution.De
 	}
 
 	if len(descriptors) != len(configRootFS.DiffIDs) {
+		logrus.WithFields(logrus.Fields{
+			"len(descriptors)":          len(descriptors),
+			"len(configRootFS.DiffIDs)": len(configRootFS.DiffIDs),
+			"descriptors":               fmt.Sprintf("%#v", descriptors),
+			"configRootFS":              fmt.Sprintf("%#v", configRootFS),
+		}).Error("rootFS mismatch before downloading layers")
 		return "", errRootFSMismatch
 	}
 
@@ -713,11 +719,24 @@ func (p *v2Puller) pullSchema2Layers(ctx context.Context, target distribution.De
 		// Otherwise the image config could be referencing layers that aren't
 		// included in the manifest.
 		if len(downloadedRootFS.DiffIDs) != len(configRootFS.DiffIDs) {
+			logrus.WithFields(logrus.Fields{
+				"len(downloadedRootFS.DiffIDs)": len(downloadedRootFS.DiffIDs),
+				"len(configRootFS.DiffIDs)":     len(configRootFS.DiffIDs),
+				"downloadedRootFS":              fmt.Sprintf("%#v", downloadedRootFS),
+				"configRootFS":                  fmt.Sprintf("%#v", configRootFS),
+			}).Error("rootFS mismatch after downloading layers")
 			return "", errRootFSMismatch
 		}
 
 		for i := range downloadedRootFS.DiffIDs {
 			if downloadedRootFS.DiffIDs[i] != configRootFS.DiffIDs[i] {
+				logrus.WithFields(logrus.Fields{
+					"i":                           i,
+					"downloadedRootFS.DiffIDs[i]": downloadedRootFS.DiffIDs[i],
+					"configRootFS.DiffIDs[i]":     configRootFS.DiffIDs[i],
+					"downloadedRootFS":            fmt.Sprintf("%#v", downloadedRootFS),
+					"configRootFS":                fmt.Sprintf("%#v", configRootFS),
+				}).Error("rootFS mismatch in layer")
 				return "", errRootFSMismatch
 			}
 		}


### PR DESCRIPTION
We currently do not log any information to help us understanding the
underlying issue -- not even to identify what is the exact point in
which the error is raised. This commit improves on this situation.

Meant to help with #244.