### PR TITLE
Fix crash with PPP interface with nil dst address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ ARG TARGETARCH
 RUN /download-frozen-image-v2.sh /build \
         busybox:latest@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209 \
         busybox:glibc@sha256:1f81263701cddf6402afe9f33fca0266d9fff379e59b1748f33d3072da71ee85 \
-        debian:bullseye-slim@sha256:dacf278785a4daa9de07596ec739dbc07131e189942772210709c5c0777e8437 \
+        debian:bullseye@sha256:7190e972ab16aefea4d758ebe42a293f4e5c5be63595f4d03a5b9bf6839a4344 \
         hello-world:latest@sha256:d58e752213a51785838f9eed2b7a498ffa1cb3aa7f946dda11af39286c3db9a9 \
         arm32v7/hello-world:latest@sha256:50b8560ad574c779908da71f7ce370c0a2471c098d44d1c8f6b513c5a55eeeb1
 # See also frozenImages in "testutil/environment/protect.go" (which needs to be updated when adding images to this list)

--- a/vendor.conf
+++ b/vendor.conf
@@ -60,7 +60,7 @@ github.com/hashicorp/go-multierror                  886a7fbe3eb1c874d46f623bfa70
 github.com/hashicorp/serf                           598c54895cc5a7b1a24a398d635e8c0ea0959870
 github.com/docker/libkv                             458977154600b9f23984d9f4b82e79570b5ae12b
 github.com/vishvananda/netns                        db3c7e526aae966c4ccfa6c8189b693d6ac5d202
-github.com/vishvananda/netlink                      f049be6f391489d3f374498fe0c8df8449258372 # v1.1.0
+github.com/vishvananda/netlink                      6236117f04b0e3512d396660b61d5b1e47a01606 https://github.com/balena-os/balena-netlink # v1.1.0 + "Correct panic when IPv4 lacks IFA_ADDRESS address"
 github.com/moby/ipvs                                4566ccea0e08d68e9614c3e7a64a23b850c4bb35 # v1.0.1
 
 # When updating, consider updating TOMLV_COMMIT in hack/dockerfile/install/tomlv.installer accordingly

--- a/vendor/github.com/vishvananda/netlink/addr_linux.go
+++ b/vendor/github.com/vishvananda/netlink/addr_linux.go
@@ -271,7 +271,7 @@ func parseAddr(m []byte) (addr Addr, family, index int, err error) {
 	// But obviously, as there are IPv6 PtP addresses, too,
 	// IFA_LOCAL should also be handled for IPv6.
 	if local != nil {
-		if family == FAMILY_V4 && local.IP.Equal(dst.IP) {
+		if family == FAMILY_V4 && dst != nil && local.IP.Equal(dst.IP) {
 			addr.IPNet = dst
 		} else {
 			addr.IPNet = local


### PR DESCRIPTION
balenaEngine initialization would fail on devices connected to the
network via PPP (Point-to-Point Protocol) and with a nil destination
address (0.0.0.0):

    panic: runtime error: invalid memory address or nil pointer dereference

This commit updates the netlink dependency to a fork where we
cherry-picked the correction. This correction wasn't available in any
stable release of netlink, so we opted to use this fork instead of
relying on a beta netlink version. We can obsolete our fork once Moby
starts using a netlink version that includes the fix.
