### PR TITLE
Lmb/fix oob slice

### DIFF
--- a/pkg/ioutils/concat.go
+++ b/pkg/ioutils/concat.go
@@ -1,8 +1,8 @@
 package ioutils
 
 import (
-	"io"
 	"errors"
+	"io"
 )
 
 func min(x, y int) int {
@@ -38,11 +38,11 @@ func SeekerSize(s io.Seeker) (int64, error) {
 }
 
 type concatReadSeekCloser struct {
-	a ReadSeekCloser
+	a     ReadSeekCloser
 	aSize int64
-	b ReadSeekCloser
+	b     ReadSeekCloser
 	bSize int64
-	off int64
+	off   int64
 }
 
 func (self *concatReadSeekCloser) Read(p []byte) (n int, err error) {
@@ -52,7 +52,7 @@ func (self *concatReadSeekCloser) Read(p []byte) (n int, err error) {
 			return 0, err
 		}
 
-		nA, err := io.ReadFull(self.a, p[:min(len(p), int(self.aSize - self.off))])
+		nA, err := io.ReadFull(self.a, p[:min(len(p), int(self.aSize-self.off))])
 		if err != nil {
 			return 0, err
 		}
@@ -60,12 +60,13 @@ func (self *concatReadSeekCloser) Read(p []byte) (n int, err error) {
 	}
 
 	// if the read ends within b
-	if self.off + int64(len(p)) >= self.aSize {
-		if _, err := self.b.Seek(int64(max(0, int(self.off - self.aSize))), io.SeekStart); err != nil {
+	if self.off+int64(len(p)) >= self.aSize {
+		if _, err := self.b.Seek(int64(max(0, int(self.off-self.aSize))), io.SeekStart); err != nil {
 			return 0, err
 		}
 
-		nB, err := io.ReadFull(self.b, p[min(len(p), max(int(self.aSize - self.off), 0)):])
+		nB, err := io.ReadFull(self.b, p[min(len(p), max(int(self.aSize-self.off), 0)):])
+
 		if err != nil {
 			return 0, err
 		}

--- a/pkg/ioutils/concat.go
+++ b/pkg/ioutils/concat.go
@@ -5,14 +5,22 @@ import (
 	"io"
 )
 
-func min(x, y int) int {
-	if x < y {
-		return x
+// clampSliceIndex clamps index to be between min and max (inclusive). As the
+// name suggests, the function is designed to be especially useful for slice
+// indices -- and in particular, to do so safely in both 32- and 64-bit
+// platforms.
+func clampSliceIndex(index int64, min, max int) int {
+	if index < int64(min) {
+		return min
 	}
-	return y
+	if index > int64(max) {
+		return max
+	}
+	return int(index)
 }
 
-func max(x, y int) int {
+// max64 returns the larger of two int64 values.
+func max64(x, y int64) int64 {
 	if x < y {
 		return y
 	}
@@ -52,7 +60,9 @@ func (self *concatReadSeekCloser) Read(p []byte) (n int, err error) {
 			return 0, err
 		}
 
-		nA, err := io.ReadFull(self.a, p[:min(len(p), int(self.aSize-self.off))])
+		i := clampSliceIndex(self.aSize-self.off, 0, len(p))
+		nA, err := io.ReadFull(self.a, p[:i])
+
 		if err != nil {
 			return 0, err
 		}
@@ -61,11 +71,12 @@ func (self *concatReadSeekCloser) Read(p []byte) (n int, err error) {
 
 	// if the read ends within b
 	if self.off+int64(len(p)) >= self.aSize {
-		if _, err := self.b.Seek(int64(max(0, int(self.off-self.aSize))), io.SeekStart); err != nil {
+		if _, err := self.b.Seek(max64(0, self.off-self.aSize), io.SeekStart); err != nil {
 			return 0, err
 		}
 
-		nB, err := io.ReadFull(self.b, p[min(len(p), max(int(self.aSize-self.off), 0)):])
+		i := clampSliceIndex(self.aSize-self.off, 0, len(p))
+		nB, err := io.ReadFull(self.b, p[i:])
 
 		if err != nil {
 			return 0, err


### PR DESCRIPTION
**- What I did**

Fix the "slice bounds out of range" errors that occasionally happen while applying large deltas on 32-bit devices.

**- How I did it**

The root cause of this issue was an integer overflow in 32-bit platforms
-- specifically, when explicitly converting `io.Reader` offsets
(`int64`) to slice indices (`int`, which is only 32-bit long on 32-bit
platforms).
    
We already had in place the checks supposed to ensure slice bounds where
always within the expected bounds. So, in a way, this commit just
re-organizes the code so that we perform safely this required `int64` to
`int` type conversion.

**- How to verify it**

TODO!

**- Description for the changelog**
Fix "slice bounds out of range" while applying deltas
