### PR TITLE
Improve error reporting for delta base image loading

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -600,7 +600,7 @@ func (p *v2Puller) pullSchema2Layers(ctx context.Context, target distribution.De
 
 			stream, err := p.config.ImageStore.GetTarSeekStream(digest)
 			if err != nil {
-				return "", err
+				return "", fmt.Errorf("loading delta base image %v: %w", digest, err)
 			}
 			defer stream.Close()
 


### PR DESCRIPTION
This adds some context to the error message when there's some error
loading the delta base image (for example, when the delta base image is
not found locally).

The error message we had before was generic and low-level, which didn't
give any clues about what lead to the error.

Signed-off-by: Leandro Motta Barros <leandro@balena.io>
Change-type: patch

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/balena-os/balena-engine/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For general information on balenaEngine visit https://www.balena.io/engine

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
