### PR TITLE
Ignore missing config.v2.json files on migration

### DIFF
--- a/pkg/storagemigration/migrate.go
+++ b/pkg/storagemigration/migrate.go
@@ -336,10 +336,14 @@ func SwitchAllContainersStorageDriver(root, newStorageDriver string) error {
 	logrus.Debugf("migrating %v container(s) to %s", len(containerIDs), newStorageDriver)
 	for _, containerID := range containerIDs {
 		err := switchContainerStorageDriver(root, containerID, newStorageDriver)
-		if err != nil {
+		switch err {
+		case nil:
+			logrus.WithField("container_id", containerID).Debugf("reconfigured storage-driver to %s", newStorageDriver)
+		case errNoConfigV2JSON:
+			logrus.WithField("container_id", containerID).Warning("ignoring container without config.v2.json")
+		default:
 			return fmt.Errorf("Error rewriting container config for %s: %v", containerID, err)
 		}
-		logrus.WithField("container_id", containerID).Debugf("reconfigured storage-driver to %s", newStorageDriver)
 	}
 	return nil
 }


### PR DESCRIPTION
We have seen some cases in which the file
`/var/lib/docker/containers/<UUID>/config.v2.json` was not found for
certain UUIDs. This causes the whole migration to fail and, worse,
causes our migration cleanup code to fail.

A missing `config.v2.json` indicates that directory does not contain a
valid container, so we should not even try to migrate them. That's what
this commit does: it makes the migration ignore directories with a
missing `config.v2.json`.

I don't think we should have directories like this in the first place,
this is probably the side effect of some other issue. That said, Docker
itself ignores these directories (after logging a warning) during
startup, so here are just bringing the Engine in line with the standard
behavior.

Signed-off-by: Leandro Motta Barros <leandro@balena.io>
Change-type: patch

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/balena-os/balena-engine/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For general information on balenaEngine visit https://www.balena.io/engine

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
