### PR TITLE
Cross-build the dynbinary target

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -18,6 +18,9 @@ runs:
   # https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
   using: "composite"
   steps:
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
@@ -25,9 +28,9 @@ runs:
     - name: Build release
       uses: docker/bake-action@v2
       with:
-        targets: cross
-      env:
-        DOCKER_CROSSPLATFORMS: ${{ env.matrix_value }}
+        targets: dynbinary
+        set: |
+          *.platform=${{ env.matrix_value }}
 
     # https://github.com/product-os/scripts/tree/master/balena-engine
     # https://github.com/product-os/ci-images/tree/master/pipelines/balena-engine
@@ -51,7 +54,7 @@ runs:
         mkdir -p dist
 
         tar -czvf dist/balena-engine-${version}-${arch}.tar.gz \
-          -C bundles/cross/${{ env.matrix_value }} .
+          -C bundles/dynbinary-daemon .
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
The existing cross target does not disable netgo or osusergo so instead we will use QEMU to build dynbinary for other platforms.

Change-type: patch
Signed-off-by: Kyle Harding <kyle@balena.io>

As expected, cross-building with emulation (QEMU) is much slower than with the Golang toolchains, but it produces the dynamic binaries we need without modifying the upstream Moby build scripts.