### PR TITLE
Set the delta image store, fix delta-based HUPs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,6 +28,47 @@ Project](https://github.com/moby/moby/) repo.
       function](https://github.com/balena-os/balena-engine/blob/ad3f3a029cd911d4919e079df16e97922c3c437a/cmd/balena-engine/main.go#L25),
       where we dispatch the execution to the appropriate `Main()`.
 
+### Unique features
+
+This is an incomplete list of features unique to balenaEngine. I hope to make
+this more complete over time, with pointers to the relevant code.
+
+#### Delta updates
+
+With deltas we allow users to pull only the differences between an image they
+already have (the *basis*) and one they want to have (the *target*). Spares
+bandwidth from users and balena alike!
+
+#### Resilient image pulls
+
+In the event of network issues while pulling an image, balenaEngine will keep
+trying to resume the interrupted download for some time without the need of
+restarting from scratch. This is very useful for devices working with an
+unstable Internet connection.
+
+#### Alternative delta data root
+
+TL;DR: Enables the use of deltas for Host OS Updates (HUPs).
+
+Docker stores images in what is unsurprisingly called an Image Store. All images
+you pull or build are placed in a single Image Store. If you are familiar with
+that, the Image Store data is normally placed (along with other things) under
+`/var/lib/docker/` (or `/mnt/data/docker/` in the case of balenaOS).
+
+With balenaEngine we offer two command-line options, `--delta-data-root` and
+`--delta-storage-driver`, that allow to configure a second Image Store which is
+used exclusively when looking for the basis images for deltas.
+
+balenaEngine on balenaOS will normally not use these options: just like with
+Docker, a single Image Store is used. When we do a delta update of a user
+container, the basis will be in this Image Store.
+
+The only situation we use these options is during Host OS Updates (HUPs). In
+this case, the basis image (i.e., the old balenaOS version) is on [a different
+partition](https://os-docs.balena.io/architecture#image-partition-layout) than
+the target image. So, we use `--delta-data-root` and `--delta-storage-driver` to
+make sure we can find the basis image on that other partition.
+
 ### Day-to-day tasks / Cheat sheet
 
 Unless otherwise is specified, all commands described below are to be executed

--- a/daemon/images/image_pull.go
+++ b/daemon/images/image_pull.go
@@ -106,7 +106,7 @@ func (i *ImageService) pullImageWithReference(ctx context.Context, ref reference
 		leases:       i.leases,
 	}
 	imageStore := &imageStoreForPull{
-		ImageConfigStore: distribution.NewImageConfigStoreFromStore(i.imageStore, nil),
+		ImageConfigStore: distribution.NewImageConfigStoreFromStore(i.imageStore, i.deltaStore),
 		ingested:         cs,
 		leases:           i.leases,
 	}
@@ -120,8 +120,7 @@ func (i *ImageService) pullImageWithReference(ctx context.Context, ref reference
 			ImageEventLogger: i.LogImageEvent,
 			MetadataStore:    i.distributionMetadataStore,
 			ImageStore:       imageStore,
-			// ImageStore:    distribution.NewImageConfigStoreFromStore(i.imageStore, i.deltaStore),
-			ReferenceStore: i.referenceStore,
+			ReferenceStore:   i.referenceStore,
 		},
 		DownloadManager: i.downloadManager,
 		Schema2Types:    distribution.ImageTypes,

--- a/integration/image/delta_test.go
+++ b/integration/image/delta_test.go
@@ -5,9 +5,11 @@ import (
 	"bufio"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -15,6 +17,7 @@ import (
 	"github.com/docker/docker/api/types"
 	apiclient "github.com/docker/docker/client"
 	"github.com/docker/docker/daemon/graphdriver/copy"
+	"github.com/docker/docker/testutil/daemon"
 	"github.com/docker/docker/testutil/fakecontext"
 	"github.com/docker/docker/testutil/registry"
 	"gotest.tools/v3/assert"
@@ -399,6 +402,98 @@ func TestDeltaCorrectness(t *testing.T) {
 	}
 }
 
+// TestPullUsingDeltaStore checks if balenaEngine's alternative delta root
+// feature is working as expected.
+func TestPullUsingDeltaStore(t *testing.T) {
+	// Basis and target for delta.
+	const basis = "busybox:1.34"
+	const target = "busybox:1.35"
+	delta := deltaName(basis, target)
+
+	// We'll push the delta to this registry.
+	defer setupTemporaryTestRegistry(t)()
+
+	// Create a delta, push it to the temporary test registry.
+	func() {
+		d := daemon.New(t)
+		d.Start(t)
+		defer d.Stop(t)
+
+		client := d.NewClientT(t)
+		ctx := context.Background()
+
+		pullAndTag(ctx, t, client, basis, ttrImageName(basis))
+		pullAndTag(ctx, t, client, target, ttrImageName(target))
+
+		ttrCreateDelta(ctx, t, client, basis, target)
+		ttrPushImage(ctx, t, client, delta)
+	}()
+
+	// This is the path we'll eventually use as the delta data root.
+	deltaDataRootDir, err := os.MkdirTemp("", "")
+	assert.NilError(t, err)
+	defer os.RemoveAll(deltaDataRootDir)
+
+	// Place the basis image on `deltaDataRootDir`. We do that by pulling it from
+	// the temporary registry to a temporary daemon that uses `deltaDataRootDir`
+	// as its regular data root.
+	func() {
+		d := daemon.New(t)
+		args := []string{
+			fmt.Sprintf("--data-root=%s", deltaDataRootDir),
+		}
+		d.Start(t, args...)
+		defer d.Stop(t)
+
+		client := d.NewClientT(t)
+		ctx := context.Background()
+
+		rc, err := client.ImagePull(ctx, basis, types.ImagePullOptions{})
+		_, err = readAllAndClose(rc)
+		assert.NilError(t, err)
+
+		imgs, err := client.ImageList(ctx, types.ImageListOptions{All: true})
+		assert.NilError(t, err)
+		assert.Equal(t, len(imgs), 1)
+
+		assert.NilError(t, err)
+	}()
+
+	// Just to help detecting issues with the test itself, try to pull the delta
+	// from the temporary test registry using a daemon that doesn't have the
+	// delta data root set. It should fail, because this daemon doesn't have
+	// access to the basis image.
+	func() {
+		d := daemon.New(t)
+		d.Start(t)
+		defer d.Stop(t)
+
+		client := d.NewClientT(t)
+		ctx := context.Background()
+
+		err = ttrPullImageNoAsserts(ctx, client, delta)
+		assert.Error(t, err, "image pull not successful")
+	}()
+
+	// Finally everything is set up for the real test. Create a daemon using
+	// `deltaDataRootDir` as the delta data root, then try to pull the delta. It
+	// should work.
+	func() {
+		d := daemon.New(t)
+		args := []string{
+			fmt.Sprintf("--delta-data-root=%s", deltaDataRootDir),
+			fmt.Sprintf("--delta-storage-driver=%s", d.StorageDriver()),
+		}
+		d.Start(t, args...)
+		defer d.Stop(t)
+
+		client := d.NewClientT(t)
+		ctx := context.Background()
+
+		ttrPullImage(ctx, t, client, delta)
+	}()
+}
+
 //
 // Temporary Test Registry (TTR) helper functions
 //
@@ -482,16 +577,31 @@ func ttrPushImage(ctx context.Context, t *testing.T, client apiclient.APIClient,
 	}
 }
 
-// ttrPullImage pulls a given image from the temporary test
-// registry. The image parameter must not include the registry name.
-func ttrPullImage(ctx context.Context, t *testing.T, client apiclient.APIClient, image string) {
+// ttrPullImage pulls a given image from the temporary test registry. The image
+// parameter must not include the registry name. Unlike the typical ttr*()
+// function, this one returns an error instead of doing the asserts internally.
+func ttrPullImageNoAsserts(ctx context.Context, client apiclient.APIClient, image string) error {
 	rc, err := client.ImagePull(ctx, ttrImageName(image), types.ImagePullOptions{RegistryAuth: "{}"})
-	assert.Assert(t, err)
+	if err != nil {
+		return err
+	}
 	if rc != nil {
 		body, err := readAllAndClose(rc)
-		assert.Assert(t, err)
-		assert.Assert(t, strings.Contains(body, "Status: Downloaded newer image"))
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(body, "Status: Downloaded newer image") {
+			return errors.New("image pull not successful")
+		}
 	}
+	return nil
+}
+
+// ttrPullImage pulls a given image from the temporary test registry. The image
+// parameter must not include the registry name. Asserts for any error.
+func ttrPullImage(ctx context.Context, t *testing.T, client apiclient.APIClient, image string) {
+	err := ttrPullImageNoAsserts(ctx, client, image)
+	assert.NilError(t, err)
 }
 
 // ttrQueryDeltaSize returns the size in bytes of a delta image.
@@ -556,7 +666,9 @@ func ttrImageHash(ctx context.Context, t *testing.T, client apiclient.APIClient,
 // deltaName returns the name we'll use in the tests for a delta from base to
 // target.
 func deltaName(base, target string) string {
-	return "delta-" + base + "-" + target
+	cleanBase := strings.ReplaceAll(base, ":", "_")
+	cleanTarget := strings.ReplaceAll(target, ":", "_")
+	return "delta-" + cleanBase + "-" + cleanTarget
 }
 
 // readAllAndClose reads everything from r, closes it, and returns whatever was
@@ -578,4 +690,17 @@ func sliceContains(haystack []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+// pullAndTag pulls a given image and tags it with a given tag. This function
+// asserts that all operations are successful.
+func pullAndTag(ctx context.Context, t *testing.T, client apiclient.APIClient, image, tag string) {
+	rc, err := client.ImagePull(ctx, image, types.ImagePullOptions{})
+	assert.NilError(t, err)
+
+	_, err = readAllAndClose(rc)
+	assert.NilError(t, err)
+
+	err = client.ImageTag(ctx, image, tag)
+	assert.NilError(t, err)
 }


### PR DESCRIPTION
We apparently have broken this during the 20.10 merge. Not setting the delta image store breaks delta-based balenaOS updates (HUPs).

(Bonus: tossed in a few commits refactoring the delta test cases a bit for simplicity and clarity.)

Fixes #318

Testing:

* Tested manually: on a Pi 3 running a recent (not latest) balenaOS, ran a HUP e checked in the logs that the delta-based HUP failed. Compiled a version of the Engine from my branch, replaced the Engine on the device, tried another HUP: logs no longer showed an error for the delta-based HUP.
* Added an integration test case that pulls a delta whose basis image is present only in the directory specified as the delta image root. This test case failed before the changes, and passes after them.
* Considered adding a test case to balenaOS (focusing specifically on the HUP), but it appeared to be quite a bit of work. I don't think such test would add very much safety on top of what the test above provides.
