### PR TITLE
Revert "Cross-build the dynbinary target"

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -18,9 +18,6 @@ runs:
   # https://docs.github.com/en/actions/creating-actions/creating-a-composite-action
   using: "composite"
   steps:
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
 
@@ -28,9 +25,9 @@ runs:
     - name: Build release
       uses: docker/bake-action@v2
       with:
-        targets: dynbinary
-        set: |
-          *.platform=${{ env.matrix_value }}
+        targets: cross
+      env:
+        DOCKER_CROSSPLATFORMS: ${{ env.matrix_value }}
 
     # https://github.com/product-os/scripts/tree/master/balena-engine
     # https://github.com/product-os/ci-images/tree/master/pipelines/balena-engine
@@ -54,7 +51,7 @@ runs:
         mkdir -p dist
 
         tar -czvf dist/balena-engine-${version}-${arch}.tar.gz \
-          -C bundles/dynbinary-daemon .
+          -C bundles/cross/${{ env.matrix_value }} .
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -33,10 +33,7 @@ echo
 # List of bundles to create when no argument is passed
 DEFAULT_BUNDLES=(
 	binary-daemon
-	binary-balena
 	dynbinary
-	dynbinary-balena
-
 	test-integration
 	test-docker-py
 	cross


### PR DESCRIPTION
This reverts commit 0240d94e35a43be595cd5e79b0653440c228229f.

Change-type: patch

Those needing cgo for netdns should build dynbinary from source with cgo support.

https://pkg.go.dev/net#hdr-Name_Resolution