### PR TITLE
Update libnetwork to fix port binding issue

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -47,7 +47,7 @@ github.com/grpc-ecosystem/go-grpc-middleware        df0f91b29bbbdfc3a686a7a8edbe
 # libnetwork
 
 # When updating, also update LIBNETWORK_COMMIT in hack/dockerfile/install/proxy.installer accordingly
-github.com/docker/libnetwork                        4d0934611265197ec35c1fcb6233c0e3757aecc3 https://github.com/balena-os/balena-libnetwork
+github.com/docker/libnetwork                        ace5cf58e62c8569b12363b365ee44422cb8c391 https://github.com/balena-os/balena-libnetwork
 github.com/docker/go-events                         e31b211e4f1cd09aa76fe4ac244571fab96ae47f
 github.com/armon/go-radix                           e39d623f12e8e41c7b5529e9a9dd67a1e2261f80
 github.com/armon/go-metrics                         eb0af217e5e9747e41dd5303755356b62d28e3ec

--- a/vendor/github.com/docker/libnetwork/endpoint.go
+++ b/vendor/github.com/docker/libnetwork/endpoint.go
@@ -844,10 +844,6 @@ func (ep *endpoint) Delete(force bool) error {
 		}
 	}
 
-	if err = n.getController().deleteFromStore(ep); err != nil {
-		return err
-	}
-
 	defer func() {
 		if err != nil && !force {
 			ep.dbExists = false
@@ -861,6 +857,11 @@ func (ep *endpoint) Delete(force bool) error {
 	n.getController().unWatchSvcRecord(ep)
 
 	if err = ep.deleteEndpoint(force); err != nil && !force {
+		return err
+	}
+
+	// This has to come after the sandbox and the driver to guarantee that can be the source of truth on restart cases
+	if err = n.getController().deleteFromStore(ep); err != nil {
 		return err
 	}
 

--- a/vendor/github.com/docker/libnetwork/sandbox_store.go
+++ b/vendor/github.com/docker/libnetwork/sandbox_store.go
@@ -2,7 +2,6 @@ package libnetwork
 
 import (
 	"encoding/json"
-	"sync"
 
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/osl"
@@ -207,6 +206,40 @@ func (c *controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 		return
 	}
 
+	// Get all the endpoints
+	// Use the network as the source of truth so that if there was an issue before the sandbox registered the endpoint
+	// this will be taken anyway
+	endpointsInSandboxID := map[string][]*endpoint{}
+	nl, err := c.getNetworksForScope(datastore.LocalScope)
+	if err != nil {
+		logrus.Warnf("Could not get list of networks during sandbox cleanup: %v", err)
+		return
+	}
+
+	for _, n := range nl {
+		var epl []*endpoint
+		epl, err = n.getEndpointsFromStore()
+		if err != nil {
+			logrus.Warnf("Could not get list of endpoints in network %s during sandbox cleanup: %v", n.name, err)
+			continue
+		}
+		for _, ep := range epl {
+			ep, err = n.getEndpointFromStore(ep.id)
+			if err != nil {
+				logrus.Warnf("Could not get endpoint in network %s during sandbox cleanup: %v", n.name, err)
+				continue
+			}
+			if ep.sandboxID == "" {
+				logrus.Warnf("Endpoint %s not associated to any sandbox, deleting it", ep.id)
+				ep.Delete(true)
+				continue
+			}
+
+			// Append the endpoint to the corresponding sandboxID
+			endpointsInSandboxID[ep.sandboxID] = append(endpointsInSandboxID[ep.sandboxID], ep)
+		}
+	}
+
 	for _, kvo := range kvol {
 		sbs := kvo.(*sbState)
 
@@ -252,25 +285,11 @@ func (c *controller) sandboxCleanup(activeSandboxes map[string]interface{}) {
 		c.sandboxes[sb.id] = sb
 		c.Unlock()
 
-		for _, eps := range sbs.Eps {
-			n, err := c.getNetworkFromStore(eps.Nid)
-			var ep *endpoint
-			if err != nil {
-				logrus.Errorf("getNetworkFromStore for nid %s failed while trying to build sandbox for cleanup: %v", eps.Nid, err)
-				n = &network{id: eps.Nid, ctrlr: c, drvOnce: &sync.Once{}, persist: true}
-				ep = &endpoint{id: eps.Eid, network: n, sandboxID: sbs.ID}
-			} else {
-				ep, err = n.getEndpointFromStore(eps.Eid)
-				if err != nil {
-					logrus.Errorf("getEndpointFromStore for eid %s failed while trying to build sandbox for cleanup: %v", eps.Eid, err)
-					ep = &endpoint{id: eps.Eid, network: n, sandboxID: sbs.ID}
-				}
+		// Restore all the endpoints that are supposed to be in this sandbox
+		if eps, ok := endpointsInSandboxID[sb.id]; ok {
+			for _, ep := range eps {
+				sb.addEndpoint(ep)
 			}
-			if _, ok := activeSandboxes[sb.ID()]; ok && err != nil {
-				logrus.Errorf("failed to restore endpoint %s in %s for container %s due to %v", eps.Eid, eps.Nid, sb.ContainerID(), err)
-				continue
-			}
-			sb.addEndpoint(ep)
 		}
 
 		if _, ok := activeSandboxes[sb.ID()]; !ok {


### PR DESCRIPTION
This updates balena-libnetwork to a version that should fix some port binding issues that may happen after balenaEngine or device crashes. Specifically, this balena-libnetwork version cherry-picks [this unmerged upstream patch](https://github.com/moby/libnetwork/pull/1805) (with minor changes to make it compatible with recent Moby versions).

I cannot comment on the precise details, but this patch essentially changes the order of initialization of some network-related components in order to avoid getting into a inconsistent state.

Fixes #272 (at least shall fix *some* of its occurrences)

**Testing**

Tested for regressions: Engine unit tests and integration tests passing. Tried it in a [meta-balena branch](https://github.com/balena-os/meta-balena/pull/3108); all tests passed. Also did some manual testing on a Pi 3. 

Testing for effectiveness is another story. We don't have a reliable way to reproduce the issue, so I created a version of the Engine meant to crash at a point that triggers the issue. Now, I cannot tell for sure this is reproducing exactly the same case we are seeing in practice, but to me the symptoms look close enough to give a good confidence this is a step in the right direction.

I'll describe in details what I did to reproduce the issue and test the patch because this might be a good future reference should other similar issues appear (or this one re-appear).

First, based on [this analysis](https://github.com/moby/libnetwork/issues/1790) we see that the issue happens when the Engine crashes at a more or less specific point. I tried to locate such point; not sure I found it exactly, but I found something -- and then added some code that allows us to force a crash right there:

 ```patch 
diff --git a/daemon/container_operations.go b/daemon/container_operations.go
index af69e0474b..029d8176a6 100644
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -825,6 +825,14 @@ func (daemon *Daemon) connectToNetwork(container *container.Container, idOrName
                return err
        }

+       ///////////////////
+       _, err = os.Stat("/mnt/data/crash-the-engine.please")
+       if err == nil {
+               os.Remove("/mnt/data/crash-the-engine.please")
+               panic("Geronimoooooo!")
+       }
+       //////////////////
+
        if !container.Managed {
                // add container name/alias to DNS
                if err := daemon.ActivateContainerServiceBinding(container.Name); err != nil {
```

For the test itself, I prepared two Engine versions: one containing the patch we are testing (`balena-engine-patched`), another containing the "crash code" above (`balena-engine-crashable`). I copied both to the data partition of a Pi 3, so that  I can symlink `/usr/bin/balena-engine` to either of them as needed. And then:

1. **First let's reproduce the issue.** Initial state: running `balena-engine-crashable` (but not forcing a crash yet!), user service (container) running, all nice and fine.
2. Run `ps aux | grep proxy`, check the PIDs. In my case, 2216 and 2226.
3. `touch /mnt/data/crash-the-engine.please`
4. Restart the service.
5. Engine crashes, service doesn't restart.
6. But we get our stale `balena-engine-proxy` processes holding the ports. Check with `lsof -nP -iTCP -sTCP:LISTEN` and `ps aux | grep proxy`. Notice these are new processes (PIDs 2984 and 2993 in my case) created while bringing up the service again, before the forced crash.
7. `reboot`
8. We get `balena-engine-proxy` processes even before we try to start the service (IIUC, they are created as the Engine initializes the network subsystem; it's basically trying to restore the pre-reboot state.)
9. As the device tries to start the service, we get the error we were looking for: "Failed to allocate and map port 80-80: Bind for 0.0.0.0:80 failed: port is already allocated". Service remains in the "Installed" state.
10. **Now let's test the patch.** Redo steps 1-6.
11. Replace the Engine with the patched version: `mount -o remount,rw /`, `cd /usr/bin/`, `ln -nfs /mnt/data/balena-engine-patched balena-engine`.
12. `reboot`
13. The service starts normally, no port binding issues at all!

So, looks like the patch helped, Q.E.D. :slightly_smiling_face: 

**Side note:** *If* we reboot again between steps 9 and 10 , the service starts successfully. In this case, we apparently don't create `balena-engine-proxy` processes before attempting to start the service. I don't know why this happens -- why does this second reboot (apparently) makes the internal state consistent again?
