### PR TITLE
Don't enable AppArmor if `apparmor_parser` is not present

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -175,19 +175,29 @@ suite while changing them to make use of the API.
 
 #### Vendoring
 
-Moby 22.06 will make use of the standard Go modules/vendoring system. Until
-then, we are using [vndr](https://github.com/LK4D4/vndr).
+More recent versions of Moby use of the standard Go modules/vendoring system.
+Until we update, we are using [vndr](https://github.com/LK4D4/vndr).
 
-Here's what you'd do to update a dependency:
+The safest way to vendor dependencies is this:
 
 1. Edit `vendor.conf`, making the desired dependency point to the desired
    version or commit hash.
 2. Run `make BIND_DIR=. shell` to enter into the "development environment".
    container.
-3. Run `vndr` for the desired dependency, e.g., `vndr
-   github.com/balena-os/librsync-go`.
+3. Run `./hack/vendor.sh`. This will take a while to run, and will re-download
+   all dependencies.
 4. Leave the development environment (`exit` or Ctrl+D). The code under
    `vendor/` will be updated.
+
+You probably want to stick with the steps above.
+
+However, if you are in a hurry, really know what you are doing, and don't mind
+some manual tweaking, you can ask for a single dependency to be vendored. To do
+this, simply replace step 3 above with a command like `vndr
+github.com/balena-os/librsync-go` (adjusting for the desired dependency). The
+danger is that you'll skip some smartness built into the `vendor.sh` script. For
+example, as I write this, calling `vndr` directly will *also* remove everything
+under `vendor/archive/tar/` (which is needed and must be manually restored).
 
 ## Update to a new upstream release
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -131,7 +131,7 @@ github.com/googleapis/gax-go                        bd5b16380fd03dc758d11cef74ba
 google.golang.org/genproto                          e50cd9704f63023d62cd06a1994b98227fc4d21a
 
 # containerd
-github.com/containerd/containerd                    e427a4fa7dd076978806aead28ad563cf10d126a https://github.com/balena-os/balena-containerd # 20.10.17-balena branch, equivalent to upstream's v1.6.6
+github.com/containerd/containerd                    2412f5439937b966cdd7fa4a83656371254bdc4f https://github.com/balena-os/balena-containerd # 20.10.17-balena branch, equivalent to upstream's v1.6.6
 github.com/containerd/fifo                          650e8a8a179d040123db61f016cb133143e7a581 # v1.0.0
 github.com/containerd/continuity                    092b2c8f580622aee465fd5d6aba1dc8fad58b56 # v0.2.2
 github.com/containerd/cgroups                       1df78138f1e1e6ee593db155c6b369466f577651 # v1.0.3

--- a/vendor/github.com/containerd/containerd/pkg/apparmor/apparmor.go
+++ b/vendor/github.com/containerd/containerd/pkg/apparmor/apparmor.go
@@ -16,12 +16,13 @@
 
 package apparmor
 
-// HostSupports returns true if apparmor is enabled for the host, // On non-Linux returns false
-// On Linux returns true if apparmor_parser is enabled, and if we
-//  are not running docker-in-docker.
+// HostSupports returns true if apparmor is enabled for the host:
+//   - On Linux returns true if apparmor is enabled, apparmor_parser is
+//     present, and if we are not running docker-in-docker.
+//   - On non-Linux returns false.
 //
-//  It is a modified version of libcontainer/apparmor.IsEnabled(), which does not
-//  check for apparmor_parser to be present, or if we're running docker-in-docker.
+// This is derived from libcontainer/apparmor.IsEnabled(), with the addition
+// of checks for apparmor_parser to be present and docker-in-docker.
 func HostSupports() bool {
 	return hostSupports()
 }

--- a/vendor/github.com/containerd/containerd/pkg/apparmor/apparmor_linux.go
+++ b/vendor/github.com/containerd/containerd/pkg/apparmor/apparmor_linux.go
@@ -29,14 +29,16 @@ var (
 // hostSupports returns true if apparmor is enabled for the host, if
 // apparmor_parser is enabled, and if we are not running docker-in-docker.
 //
-// It is a modified version of libcontainer/apparmor.IsEnabled(), which does not
-// check for apparmor_parser to be present, or if we're running docker-in-docker.
+// This is derived from libcontainer/apparmor.IsEnabled(), with the addition
+// of checks for apparmor_parser to be present and docker-in-docker.
 func hostSupports() bool {
 	checkAppArmor.Do(func() {
 		// see https://github.com/opencontainers/runc/blob/0d49470392206f40eaab3b2190a57fe7bb3df458/libcontainer/apparmor/apparmor_linux.go
 		if _, err := os.Stat("/sys/kernel/security/apparmor"); err == nil && os.Getenv("container") == "" {
-			buf, err := os.ReadFile("/sys/module/apparmor/parameters/enabled")
-			appArmorSupported = err == nil && len(buf) > 1 && buf[0] == 'Y'
+			if _, err = os.Stat("/sbin/apparmor_parser"); err == nil {
+				buf, err := os.ReadFile("/sys/module/apparmor/parameters/enabled")
+				appArmorSupported = err == nil && len(buf) > 1 && buf[0] == 'Y'
+			}
 		}
 	})
 	return appArmorSupported


### PR DESCRIPTION
This updates balena-containerd to a new version in which we cherry-picked the change from here: https://github.com/containerd/containerd/pull/8086

This change avoids enabling AppArmor if the `/sbin/apparmor_parser` binary is not found in the system.