### PR TITLE
Simplify development doc 'Build and run' instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -126,8 +126,8 @@ can run it. What I usually do to run the Engine inside this container is:
 # Copy the binary and symlinks to somewhere in the $PATH
 cp bundles/dynbinary-daemon/balena* /bin
 
-# Run the required daemons in the background
-balena-engine-containerd &
+# Run the required daemons in the background.
+# The engine daemon also starts the balena-engine-containerd daemon
 balena-engine-daemon &
 
 # Now you can run balena-engine as you wish


### PR DESCRIPTION
**- What I did**

Simple update to development doc 'Build and run' instructions. It's not necessary to explicitly start `balena-engine-containerd`; this is done automatically by `balena-engine-daemon`.

**- How to verify it**

Review `DEVELOPMENT.md`.

**- Description for the changelog**

Simplify development doc 'Build and run' instructions