### PR TITLE
Stub the kernel version check

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -310,6 +310,9 @@ func adjustParallelLimit(n int, limit int) int {
 }
 
 func checkKernel() error {
+	// Stub the kernel check as the builder workers are using the UNAME26 personality
+	// to return armv6l
+	return nil
 	// Check for unsupported kernel versions
 	// FIXME: it would be cleaner to not test for specific versions, but rather
 	// test for specific functionalities.


### PR DESCRIPTION
Stub the kernel check as the builder workers are using the UNAME26 personality to return armv6l

Change-type: patch
See: https://balena.zulipchat.com/#narrow/stream/346007-balena-io.2FbalenaCloud/topic/setarch.20and.20uname-2.2E6
See: https://github.com/balena-io/balena-builder-worker/pull/45
See: https://github.com/balena-io/balena-builder-worker/actions/runs/7064499456/job/19232692890?pr=45#step:19:282