### PR TITLE
Bugfix: Don't close base images prematurely

### DIFF
--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -592,7 +592,11 @@ func (p *v2Puller) pullSchema2Layers(ctx context.Context, target distribution.De
 			// Target image already exists locally, no need to pull anything
 			return digest, nil
 		}
-		deltaBase, err = DeltaBaseImageFromConfig(img.Config, p.config.ImageStore)
+		deltaBaseCloser, err := DeltaBaseImageFromConfig(img.Config, p.config.ImageStore)
+		if deltaBaseCloser != nil {
+			defer deltaBaseCloser.Close()
+		}
+		deltaBase = deltaBaseCloser
 		if err != nil {
 			return "", err
 		}
@@ -1029,6 +1033,8 @@ func toOCIPlatform(p manifestlist.PlatformSpec) specs.Platform {
 // image associated with imgConfig. Passing an imgConfig that is not a delta
 // image is not considered an error: in this case the function returns a nil
 // ReadSeekCloser (and a nil error).
+//
+// The caller is responsible for Close()ing the returned stream.
 func DeltaBaseImageFromConfig(imgConfig *container.Config, imgConfigStore ImageConfigStore) (ioutils.ReadSeekCloser, error) {
 	if base, ok := imgConfig.Labels["io.resin.delta.base"]; ok {
 		digest, err := digest.Parse(base)
@@ -1040,7 +1046,6 @@ func DeltaBaseImageFromConfig(imgConfig *container.Config, imgConfigStore ImageC
 		if err != nil {
 			return nil, fmt.Errorf("loading delta base image %q: %w", digest, err)
 		}
-		defer stream.Close()
 
 		return stream, nil
 	}

--- a/image/tarexport/load.go
+++ b/image/tarexport/load.go
@@ -114,7 +114,11 @@ func (l *tarexporter) Load(inTar io.ReadCloser, outStream io.Writer, quiet bool)
 				return nil
 			}
 
-			deltaBase, err = mobyDistribution.DeltaBaseImageFromConfig(img.Config, imgConfigStore)
+			deltaBaseCloser, err := mobyDistribution.DeltaBaseImageFromConfig(img.Config, imgConfigStore)
+			if deltaBaseCloser != nil {
+				defer deltaBaseCloser.Close()
+			}
+			deltaBase = deltaBaseCloser
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This fixes a bug introduced in the refactoring made during the work on [Delta on load](https://github.com/balena-os/balena-engine/pull/374). The previous implementation was closing the base image stream before it was even used.

This effectively marked layers as no longer locked, which means other concurrent tasks would be able to remove them while they were still needed. So, this PR is very likely to help with #444 -- possibly solving it entirely (though it's hard to test or otherwise confirm this with 100% certainty).

The solution implemented here is simple enough: we make it clear who is responsible for closing this stream, and ensure it is closed only after it's used.
