### PR TITLE
Backport moby integration test fix

### DIFF
--- a/contrib/download-frozen-image-v2.sh
+++ b/contrib/download-frozen-image-v2.sh
@@ -59,30 +59,11 @@ fetch_blob() {
 	shift
 	local curlArgs=("$@")
 
-	local curlHeaders
-	curlHeaders="$(
-		curl -S "${curlArgs[@]}" \
-			-H "Authorization: Bearer $token" \
-			"$registryBase/v2/$image/blobs/$digest" \
-			-o "$targetFile" \
-			-D-
-	)"
-	curlHeaders="$(echo "$curlHeaders" | tr -d '\r')"
-	if grep -qE "^HTTP/[0-9].[0-9] 3" <<< "$curlHeaders"; then
-		rm -f "$targetFile"
-
-		local blobRedirect
-		blobRedirect="$(echo "$curlHeaders" | awk -F ': ' 'tolower($1) == "location" { print $2; exit }')"
-		if [ -z "$blobRedirect" ]; then
-			echo >&2 "error: failed fetching '$image' blob '$digest'"
-			echo "$curlHeaders" | head -1 >&2
-			return 1
-		fi
-
-		curl -fSL "${curlArgs[@]}" \
-			"$blobRedirect" \
-			-o "$targetFile"
-	fi
+	curl -L -S "${curlArgs[@]}" \
+		-H "Authorization: Bearer $token" \
+		"$registryBase/v2/$image/blobs/$digest" \
+		-o "$targetFile" \
+		-D-
 }
 
 # handle 'application/vnd.docker.distribution.manifest.v2+json' manifest


### PR DESCRIPTION
See moby/moby#50655 and moby/moby#50662. It's a test specific problem apparently triggered by GitHub rate limiting and addressed in August. This explains why it happens without a code change.

Change-type: patch

**- How to verify it**
Run integration tests like below.
```
make TEST_SKIP_INTEGRATION_CLI=1 test-integration
```

**- Description for the changelog**
Integration test fix unrelated to application code