### PR TITLE
builder: disable buildkit dependencies with no_buildkit tag

### DIFF
--- a/builder/builder-next/adapters/containerimage/pull.go
+++ b/builder/builder-next/adapters/containerimage/pull.go
@@ -1,3 +1,6 @@
+//go:build !no_buildkit
+// +build !no_buildkit
+
 package containerimage
 
 import (

--- a/builder/builder-next/adapters/localinlinecache/inlinecache.go
+++ b/builder/builder-next/adapters/localinlinecache/inlinecache.go
@@ -1,3 +1,6 @@
+//go:build !no_buildkit
+// +build !no_buildkit
+
 package localinlinecache
 
 import (

--- a/builder/builder-next/adapters/snapshot/layer.go
+++ b/builder/builder-next/adapters/snapshot/layer.go
@@ -1,3 +1,6 @@
+//go:build !no_buildkit
+// +build !no_buildkit
+
 package snapshot
 
 import (

--- a/builder/builder-next/adapters/snapshot/leasemanager.go
+++ b/builder/builder-next/adapters/snapshot/leasemanager.go
@@ -1,3 +1,6 @@
+//go:build !no_buildkit
+// +build !no_buildkit
+
 package snapshot
 
 import (

--- a/builder/builder-next/adapters/snapshot/snapshot.go
+++ b/builder/builder-next/adapters/snapshot/snapshot.go
@@ -1,3 +1,6 @@
+//go:build !no_buildkit
+// +build !no_buildkit
+
 package snapshot
 
 import (

--- a/builder/builder-next/builder_unsupported.go
+++ b/builder/builder-next/builder_unsupported.go
@@ -17,11 +17,13 @@ type Opt struct {
 	Dist                interface{}
 	NetworkController   interface{}
 	DefaultCgroupParent interface{}
+	RegistryHosts       interface{}
 	ResolverOpt         interface{}
 	BuilderConfig       interface{}
 	Rootless            interface{}
 	IdentityMapping     interface{}
 	DNSConfig           interface{}
+	ApparmorProfile     interface{}
 }
 
 type Builder struct{}

--- a/builder/builder-next/exporter/export.go
+++ b/builder/builder-next/exporter/export.go
@@ -1,3 +1,6 @@
+//go:build !no_buildkit
+// +build !no_buildkit
+
 package containerimage
 
 import (

--- a/builder/builder-next/exporter/writer.go
+++ b/builder/builder-next/exporter/writer.go
@@ -1,3 +1,6 @@
+//go:build !no_buildkit
+// +build !no_buildkit
+
 package containerimage
 
 import (

--- a/builder/builder-next/imagerefchecker/checker.go
+++ b/builder/builder-next/imagerefchecker/checker.go
@@ -1,3 +1,6 @@
+//go:build !no_buildkit
+// +build !no_buildkit
+
 package imagerefchecker
 
 import (

--- a/builder/builder-next/worker/gc.go
+++ b/builder/builder-next/worker/gc.go
@@ -1,3 +1,6 @@
+//go:build !no_buildkit
+// +build !no_buildkit
+
 package worker
 
 import (

--- a/builder/builder-next/worker/worker.go
+++ b/builder/builder-next/worker/worker.go
@@ -1,3 +1,5 @@
+// +build !no_buildkit
+
 package worker
 
 import (


### PR DESCRIPTION
This patch adds `// +build !no_buildkit` tags to the `builder-next`
backend implementation and its adapters. This ensures that when the
`no_buildkit` build tag is specified, the heavy BuildKit dependencies
(solver, executor, worker, etc.) are completely excluded from the
binary.

Previously, even with `no_buildkit`, many of these dependencies were
still being compiled in because they were imported by untagged files
in `builder/builder-next`.

This change effectively disables the `builder-next` backend when
`no_buildkit` is set, falling back to the stub implementation in
`builder_unsupported.go`.

Extends 383bd502decc8045a8a42bf48212d6fe8b87d94c

### Verification

I ran go list with the `no_buildkit` tag to analyze the dependency graph:

```
GOPATH=/Users/kyle GO111MODULE=off go list -tags no_buildkit -deps balena-os/balena-engine/cmd/dockerd | grep -E "github.com/moby/buildkit/(solver|executor|worker|cache|snapshot)"
```

The command returned no output (exit code 1), confirming that the heavy BuildKit packages (solver, executor, worker, cache, snapshot) are NOT included in the build.

There is also a 3.3mb reduction in binary size in the test below.

```
root@590de6032f52:/go/src/github.com/docker/docker# DOCKER_BUILDTAGS="no_btrfs no_cri no_devmapper no_zfs exclude_disk_quota exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_zfs" ./hack/make.sh dynbinary

Removing bundles/

---> Making bundle: dynbinary (in bundles/dynbinary)
Building: bundles/dynbinary-daemon/balena-engine-dev
GOOS="" GOARCH="" GOARM=""
Created binary: bundles/dynbinary-daemon/balena-engine-dev

root@590de6032f52:/go/src/github.com/docker/docker# du bundles/dynbinary-daemon/balena-engine-dev
55108   bundles/dynbinary-daemon/balena-engine-dev
root@590de6032f52:/go/src/github.com/docker/docker# DOCKER_BUILDTAGS="no_btrfs no_cri no_devmapper no_zfs exclude_disk_quota exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_zfs no_buildkit" ./hack/make.sh dynbinary

Removing bundles/

---> Making bundle: dynbinary (in bundles/dynbinary)
Building: bundles/dynbinary-daemon/balena-engine-dev
GOOS="" GOARCH="" GOARM=""
Created binary: bundles/dynbinary-daemon/balena-engine-dev

root@590de6032f52:/go/src/github.com/docker/docker# du bundles/dynbinary-daemon/balena-engine-dev
51804   bundles/dynbinary-daemon/balena-engine-dev
```

### Manual Testing

```bash
root@a6d5d42:/tmp/tmp.djT1yj4x29# echo 'FROM alpine' > Dockerfile 
root@a6d5d42:/tmp/tmp.djT1yj4x29# balena build .
Sending build context to Docker daemon  2.048kB
Step 1/1 : FROM alpine
latest: Pulling from library/alpine
6b59a28fa201: Pull complete 
Total:  [==================================================>]  4.138MB/4.138MB
Digest: sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
Status: Downloaded newer image for alpine:latest
 ---> 171e65262c80
Successfully built 171e65262c80
root@a6d5d42:/tmp/tmp.djT1yj4x29# DOCKER_BUILDKIT=1 balena build .
error during connect: Post "http://%2Fvar%2Frun%2Fbalena-engine.sock/v1.41/build?buildargs=%7B%7D&buildid=2f212535d126cb52b0da5d86a202ce3d48e35e50ba9dd17d89043f3f11e2afb0&cachefrom=%5B%5D&cgroupparent=&cpuperiod=0&cpuquota=0&cpusetcpus=&cpusetmems=&cpushares=0&dockerfile=&labels=%7B%7D&memory=0&memswap=0&networkmode=default&remote=client-session&rm=1&session=o2gvastdcxjsyyl5v3qa7so12&shmsize=0&target=&ulimits=null&version=2&volumes=null": EOF
```
```
Nov 19 20:18:54 a6d5d42 balenad[2004]: time="2025-11-19T20:18:54.075817190Z" level=warning msg="buildkit isn't supported"
Nov 19 20:18:54 a6d5d42 balenad[2004]: 2025/11/19 20:18:54 http: panic serving @: buildkit isn't supported
```
