### PR TITLE
build: drop NRI plugin from default build (-2.4 MB / -4.5%)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ DOCKER_ENVS := \
 	-e DOCKER_BUILDTAGS
 
 # balenaEngine build tags - excludes drivers that need special test privileges
-DOCKER_BUILDTAGS ?= apparmor seccomp no_btrfs no_cri no_devmapper no_zfs exclude_disk_quota exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_zfs
+DOCKER_BUILDTAGS ?= apparmor seccomp no_btrfs no_cri no_devmapper no_nri no_zfs exclude_disk_quota exclude_graphdriver_btrfs exclude_graphdriver_devicemapper exclude_graphdriver_zfs
 export DOCKER_BUILDTAGS
 
 # to allow `make BIND_DIR=. shell` or `make BIND_DIR= test`

--- a/vendor.mod
+++ b/vendor.mod
@@ -271,7 +271,7 @@ require (
 	github.com/moby/sys/userns v0.1.0 // indirect
 )
 
-replace github.com/containerd/containerd => github.com/balena-os/balena-containerd v1.7.13-0.20260330175147-b45fa1f9313a
+replace github.com/containerd/containerd => github.com/balena-os/balena-containerd v1.7.13-0.20260524124706-4ca7922eaf46
 
 replace github.com/opencontainers/runc => github.com/balena-os/balena-runc v1.2.9-0.20251114161102-6d250e9a9f03
 

--- a/vendor.sum
+++ b/vendor.sum
@@ -946,8 +946,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.26.7/go.mod h1:6h2YuIoxaMSCFf5fi1EgZ
 github.com/aws/smithy-go v1.19.0 h1:KWFKQV80DpP3vJrrA9sVAHQ5gc2z8i4EzrLhLlWXcBM=
 github.com/aws/smithy-go v1.19.0/go.mod h1:NukqUGpCZIILqqiV0NIjeFh24kd/FAa4beRb6nbIUPE=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
-github.com/balena-os/balena-containerd v1.7.13-0.20260330175147-b45fa1f9313a h1:TmvHKmehgiS6z4g07O2lRBrSEYeonLAyzbzKAUbZH2Q=
-github.com/balena-os/balena-containerd v1.7.13-0.20260330175147-b45fa1f9313a/go.mod h1:/5OMpE1p0ylxtEUGY8kuCYkDRzJm9NO1TFMWjUpdevk=
+github.com/balena-os/balena-containerd v1.7.13-0.20260524124706-4ca7922eaf46 h1:v3D18EOoO7vUZ5l7BWtDEWUjahuWnNRH1DTGuj8RXno=
+github.com/balena-os/balena-containerd v1.7.13-0.20260524124706-4ca7922eaf46/go.mod h1:/5OMpE1p0ylxtEUGY8kuCYkDRzJm9NO1TFMWjUpdevk=
 github.com/balena-os/balena-engine-cli v25.0.3-0.20260312154932-772ba939846e+incompatible h1:ZIQHbIl0lws8dx5Fg3q3i2Fk80rCRjYtQaN0ZukqI8E=
 github.com/balena-os/balena-engine-cli v25.0.3-0.20260312154932-772ba939846e+incompatible/go.mod h1:QO1dMBjQfxaXuL/iu85TiozUX6zZF7Kg2G9zunxJyWc=
 github.com/balena-os/balena-runc v1.2.9-0.20251114161102-6d250e9a9f03 h1:KAVH48GAeb2cKGuVWDayWw7WnSsat/RX9JOVWKwdyBM=

--- a/vendor/github.com/containerd/containerd/cmd/containerd/builtins/builtins.go
+++ b/vendor/github.com/containerd/containerd/cmd/containerd/builtins/builtins.go
@@ -23,7 +23,6 @@ import (
 	_ "github.com/containerd/containerd/gc/scheduler"
 	_ "github.com/containerd/containerd/leases/plugin"
 	_ "github.com/containerd/containerd/metadata/plugin"
-	_ "github.com/containerd/containerd/pkg/nri/plugin"
 	_ "github.com/containerd/containerd/plugins/sandbox"
 	_ "github.com/containerd/containerd/plugins/streaming"
 	_ "github.com/containerd/containerd/plugins/transfer"

--- a/vendor/github.com/containerd/containerd/cmd/containerd/builtins/nri.go
+++ b/vendor/github.com/containerd/containerd/cmd/containerd/builtins/nri.go
@@ -1,0 +1,23 @@
+//go:build !no_nri
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package builtins
+
+import (
+	_ "github.com/containerd/containerd/pkg/nri/plugin"
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -285,7 +285,7 @@ github.com/containerd/cgroups/v3/cgroup2/stats
 # github.com/containerd/console v1.0.5
 ## explicit; go 1.13
 github.com/containerd/console
-# github.com/containerd/containerd v1.7.12 => github.com/balena-os/balena-containerd v1.7.13-0.20260330175147-b45fa1f9313a
+# github.com/containerd/containerd v1.7.12 => github.com/balena-os/balena-containerd v1.7.13-0.20260524124706-4ca7922eaf46
 ## explicit; go 1.19
 github.com/containerd/containerd
 github.com/containerd/containerd/api/events
@@ -1991,6 +1991,6 @@ tags.cncf.io/container-device-interface/pkg/parser
 # tags.cncf.io/container-device-interface/specs-go v0.6.0
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
-# github.com/containerd/containerd => github.com/balena-os/balena-containerd v1.7.13-0.20260330175147-b45fa1f9313a
+# github.com/containerd/containerd => github.com/balena-os/balena-containerd v1.7.13-0.20260524124706-4ca7922eaf46
 # github.com/opencontainers/runc => github.com/balena-os/balena-runc v1.2.9-0.20251114161102-6d250e9a9f03
 # github.com/docker/cli => github.com/balena-os/balena-engine-cli v25.0.3-0.20260312154932-772ba939846e+incompatible


### PR DESCRIPTION
Drops ~2.4 MB / 4.5% off the balena-engine binary by adding `no_nri` to the default build tags.

See: https://github.com/balena-os/balena-containerd/commit/4ca7922eaf4678b7da1b65bc68f3d00b7b56ef20

Two commits: one bumps balena-containerd to a fork commit that splits the NRI import behind `//go:build !no_nri`, the other flips the tag on in the Makefile.

NRI is the containerd hook protocol for k8s-style plugins. We don't expose it on balenaOS, and the shim filter already keeps it from registering at startup, but the server, types, and gRPC surface still got linked in as dead code.

I measured the byte impact of pruning each candidate from the builtin plugin set. NRI was the only one that mattered:

| Rank | Candidate | Δ bytes | Δ % | New test fails |
|---|---|---|---|---|
| 1 | `pkg/nri/plugin` | **-2,390,528** | **-4.481%** | 0 |
| 2 | `plugins/transfer` + `services/transfer` | -148,808 | -0.279% | 0 |
| 3 | `plugins/sandbox` + `services/sandbox` | -83,928 | -0.157% | 0 |
| 4 | `runtime/restart/monitor` | -76,296 | -0.143% | 0 |
| 5 | `plugins/streaming` + `services/streaming` | -4,312 | -0.008% | 0 |
| 6 | `snapshots/blockfile/plugin` | -3,464 | -0.006% | 0 |
| 7 | `snapshots/native/plugin` | -3,200 | -0.006% | 0 |
| 8 | `runtime/v1/linux` | -24 | ~0% | 0 |

NRI alone is ~85% of the achievable savings. The other seven combined are ~320 KB, not worth the fork-side build-tag flags to maintain.

## Verification

All on linux/arm64 with the production tag set:

- Pre-bump baseline: 53,351,792 bytes
- Post-bump without `no_nri`: 53,351,792 bytes (byte-identical, the vendor bump alone is a no-op)
- Post-bump with `no_nri`: 50,961,264 bytes (matches the prior projection exactly)

`make test-unit` runs clean against baseline. No new failures from either commit.

## Test plan

- [x] Vendor-only build is byte-identical to baseline
- [x] `no_nri` build is 2,390,528 bytes smaller
- [x] `make test-unit` has no new failures under `no_nri`
- [ ] CI integration sweep
- [ ] meta-balena image build sanity check