### PR TITLE
vendor: bump balena-runc to restore 1777 default for bare tmpfs mounts

### DIFF
--- a/vendor.mod
+++ b/vendor.mod
@@ -273,6 +273,6 @@ require (
 
 replace github.com/containerd/containerd => github.com/balena-os/balena-containerd v1.7.13-0.20260524124706-4ca7922eaf46
 
-replace github.com/opencontainers/runc => github.com/balena-os/balena-runc v1.2.9-0.20251114161102-6d250e9a9f03
+replace github.com/opencontainers/runc => github.com/balena-os/balena-runc v1.2.9-0.20260616192057-02756e81a449
 
 replace github.com/docker/cli => github.com/balena-os/balena-engine-cli v25.0.3-0.20260312154932-772ba939846e+incompatible

--- a/vendor.sum
+++ b/vendor.sum
@@ -950,8 +950,8 @@ github.com/balena-os/balena-containerd v1.7.13-0.20260524124706-4ca7922eaf46 h1:
 github.com/balena-os/balena-containerd v1.7.13-0.20260524124706-4ca7922eaf46/go.mod h1:/5OMpE1p0ylxtEUGY8kuCYkDRzJm9NO1TFMWjUpdevk=
 github.com/balena-os/balena-engine-cli v25.0.3-0.20260312154932-772ba939846e+incompatible h1:ZIQHbIl0lws8dx5Fg3q3i2Fk80rCRjYtQaN0ZukqI8E=
 github.com/balena-os/balena-engine-cli v25.0.3-0.20260312154932-772ba939846e+incompatible/go.mod h1:QO1dMBjQfxaXuL/iu85TiozUX6zZF7Kg2G9zunxJyWc=
-github.com/balena-os/balena-runc v1.2.9-0.20251114161102-6d250e9a9f03 h1:KAVH48GAeb2cKGuVWDayWw7WnSsat/RX9JOVWKwdyBM=
-github.com/balena-os/balena-runc v1.2.9-0.20251114161102-6d250e9a9f03/go.mod h1:cC0YkmZcuvr+rtBZ6T7NBoVbMGNAdLa/21vIElJDOzI=
+github.com/balena-os/balena-runc v1.2.9-0.20260616192057-02756e81a449 h1:CUuIHBIfZ6OjHhJPyKD6DVrTILSTY+0ihQ4Tw/gksDM=
+github.com/balena-os/balena-runc v1.2.9-0.20260616192057-02756e81a449/go.mod h1:cC0YkmZcuvr+rtBZ6T7NBoVbMGNAdLa/21vIElJDOzI=
 github.com/balena-os/circbuf v0.1.3 h1:pLkTha46mQ2FOfB4l9sz4fckt8oorpVSWIp6N3xW+wE=
 github.com/balena-os/circbuf v0.1.3/go.mod h1:D8R+zPJf/Sfd43NP++rdNfGAf7KefcKG1b6k2Ww0ZzU=
 github.com/balena-os/librsync-go v0.9.0 h1:BpkzPLY9167oydsffqTyTmWoJFI/yZW4ESY9BvS6MMY=

--- a/vendor/github.com/opencontainers/runc/libcontainer/rootfs_linux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/rootfs_linux.go
@@ -511,6 +511,18 @@ func (m *mountEntry) createOpenMountpoint(rootfs string) (Err error) {
 			_ = dstFile.Close()
 		}
 	}()
+	if err == nil && m.Device == "tmpfs" {
+		// If the original target exists, copy the mode for the tmpfs mount.
+		stat, err := dstFile.Stat()
+		if err != nil {
+			return fmt.Errorf("check tmpfs source mode: %w", err)
+		}
+		dt := fmt.Sprintf("mode=%04o", syscallMode(stat.Mode()))
+		if m.Data != "" {
+			dt = dt + "," + m.Data
+		}
+		m.Data = dt
+	}
 	if err != nil {
 		if !errors.Is(err, unix.ENOENT) {
 			return fmt.Errorf("lookup mountpoint target: %w", err)
@@ -549,19 +561,6 @@ func (m *mountEntry) createOpenMountpoint(rootfs string) (Err error) {
 		if err != nil {
 			return fmt.Errorf("make mountpoint %q: %w", m.Destination, err)
 		}
-	}
-
-	if m.Device == "tmpfs" {
-		// If the original target exists, copy the mode for the tmpfs mount.
-		stat, err := dstFile.Stat()
-		if err != nil {
-			return fmt.Errorf("check tmpfs source mode: %w", err)
-		}
-		dt := fmt.Sprintf("mode=%04o", syscallMode(stat.Mode()))
-		if m.Data != "" {
-			dt = dt + "," + m.Data
-		}
-		m.Data = dt
 	}
 
 	dstFullPath, err := procfs.ProcSelfFdReadlink(dstFile)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1264,7 +1264,7 @@ github.com/opencontainers/go-digest/digestset
 github.com/opencontainers/image-spec/identity
 github.com/opencontainers/image-spec/specs-go
 github.com/opencontainers/image-spec/specs-go/v1
-# github.com/opencontainers/runc v1.1.12 => github.com/balena-os/balena-runc v1.2.9-0.20251114161102-6d250e9a9f03
+# github.com/opencontainers/runc v1.1.12 => github.com/balena-os/balena-runc v1.2.9-0.20260616192057-02756e81a449
 ## explicit; go 1.22
 github.com/opencontainers/runc
 github.com/opencontainers/runc/internal/linux
@@ -1992,5 +1992,5 @@ tags.cncf.io/container-device-interface/pkg/parser
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
 # github.com/containerd/containerd => github.com/balena-os/balena-containerd v1.7.13-0.20260524124706-4ca7922eaf46
-# github.com/opencontainers/runc => github.com/balena-os/balena-runc v1.2.9-0.20251114161102-6d250e9a9f03
+# github.com/opencontainers/runc => github.com/balena-os/balena-runc v1.2.9-0.20260616192057-02756e81a449
 # github.com/docker/cli => github.com/balena-os/balena-engine-cli v25.0.3-0.20260312154932-772ba939846e+incompatible


### PR DESCRIPTION
Pin balena-runc to the merged tmpfs fix ([balena-runc#5](https://github.com/balena-os/balena-runc/pull/5)), restoring the `1777` default for bare tmpfs mounts so non-root containers can write again. Only the `vendor.mod` runc replace directive + re-vendor.

Fixes the regression tracked in [meta-balena#3885](https://github.com/balena-os/meta-balena/issues/3885) (upstream [runc#4971](https://github.com/opencontainers/runc/issues/4971) / [#4974](https://github.com/opencontainers/runc/pull/4974)).

Verified on an `aarch64` build — bare `--tmpfs /x` as a non-root user (uid 1000):

| daemon | mount mode | non-root write |
|---|---|---|
| before (`release/v25.0`) | `755` | denied |
| after (this PR) | `1777` | ok |

---
See: https://balena.fibery.io/Work/Improvement/balenaEngine-Restore-1777-tmpfs-default-4401